### PR TITLE
Add Rust server implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ beatrice_internal_api.cp310-win_amd64.pyd
 108_average_110b_10.bin
 
 server/model_dir_static/Beatrice-JVS
+server-rs/target/
+server-rs/Cargo.lock

--- a/server-rs/Cargo.toml
+++ b/server-rs/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "server-rs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.6"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+clap = { version = "4", features = ["derive"] }

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -1,0 +1,21 @@
+# server-rs
+
+This directory contains a minimal Rust reimplementation of `MMVCServerSIO.py`.
+It uses the `tokio` ecosystem and `axum` to provide HTTP endpoints similar to
+the original Python server.
+
+## Requirements
+
+- Rust toolchain (edition 2021)
+
+## Usage
+
+```bash
+cd server-rs
+cargo run -- --port 18888 --host 127.0.0.1
+```
+
+After starting, open `http://127.0.0.1:18888/api/hello` in your browser to check
+that the server is running. The `/test` endpoint accepts a JSON payload
+containing `timestamp` and `buffer` fields and echoes them back.
+

--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -1,0 +1,62 @@
+use axum::{routing::{get, post}, Router, Json};
+use serde::{Deserialize, Serialize};
+use clap::Parser;
+use std::net::SocketAddr;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// Port to listen on
+    #[arg(short = 'p', long, default_value_t = 18888)]
+    port: u16,
+
+    /// Host address to bind
+    #[arg(long, default_value = "127.0.0.1")]
+    host: String,
+}
+
+#[derive(Serialize)]
+struct Hello {
+    result: &'static str,
+}
+
+async fn hello() -> Json<Hello> {
+    Json(Hello { result: "Index" })
+}
+
+#[derive(Deserialize)]
+struct VoiceModel {
+    timestamp: u64,
+    buffer: String,
+}
+
+#[derive(Serialize)]
+struct TestResponse {
+    timestamp: u64,
+    changed_voice_base64: String,
+}
+
+async fn test(Json(payload): Json<VoiceModel>) -> Json<TestResponse> {
+    // In the Python implementation this would run the voice changer.
+    // Here we simply echo back the input buffer.
+    Json(TestResponse {
+        timestamp: payload.timestamp,
+        changed_voice_base64: payload.buffer,
+    })
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    let app = Router::new()
+        .route("/api/hello", get(hello))
+        .route("/test", post(test));
+
+    let addr = SocketAddr::new(args.host.parse().unwrap(), args.port);
+    println!("Starting server on http://{}", addr);
+
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Summary
- add a new `server-rs` directory
- implement a minimal Rust version of `MMVCServerSIO.py` using tokio/axum
- document usage in `server-rs/README.md`
- ignore Rust build artifacts in `.gitignore`

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f9ff1b94883259c4695ef6d60b617