### PR TITLE
Add HTTPS support to Rust server

### DIFF
--- a/server-rs/Cargo.toml
+++ b/server-rs/Cargo.toml
@@ -9,3 +9,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
+axum-server = { version = "0.4", features = ["tls-rustls"] }
+rcgen = "0.13"

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -15,6 +15,13 @@ cd server-rs
 cargo run -- --port 18888 --host 127.0.0.1
 ```
 
+To enable HTTPS specify `--https`. If `ssl.key` and `ssl.cert` don't exist they
+will be generated automatically using a self–signed certificate:
+
+```bash
+cargo run -- --https
+```
+
 After starting, open `http://127.0.0.1:18888/api/hello` in your browser to check
 that the server is running. The `/test` endpoint accepts a JSON payload
 containing `timestamp` and `buffer` fields and echoes them back.

--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -1,7 +1,9 @@
 use axum::{routing::{get, post}, Router, Json};
 use serde::{Deserialize, Serialize};
 use clap::Parser;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::Path};
+use axum_server::tls_rustls::RustlsConfig;
+use rcgen::generate_simple_self_signed;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -13,6 +15,22 @@ struct Args {
     /// Host address to bind
     #[arg(long, default_value = "127.0.0.1")]
     host: String,
+
+    /// Enable HTTPS
+    #[arg(long, default_value_t = false)]
+    https: bool,
+
+    /// Path to TLS private key
+    #[arg(long, default_value = "ssl.key")]
+    https_key: String,
+
+    /// Path to TLS certificate
+    #[arg(long, default_value = "ssl.cert")]
+    https_cert: String,
+
+    /// Generate self-signed certificate when using HTTPS
+    #[arg(long, default_value_t = true)]
+    https_self_signed: bool,
 }
 
 #[derive(Serialize)]
@@ -53,10 +71,30 @@ async fn main() {
         .route("/test", post(test));
 
     let addr = SocketAddr::new(args.host.parse().unwrap(), args.port);
-    println!("Starting server on http://{}", addr);
 
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    if args.https {
+        // generate self-signed certificate if requested
+        if args.https_self_signed
+            && (!Path::new(&args.https_key).exists() || !Path::new(&args.https_cert).exists())
+        {
+            let cert = generate_simple_self_signed(["localhost".into()]).unwrap();
+            std::fs::write(&args.https_key, cert.key_pair.serialize_pem()).unwrap();
+            std::fs::write(&args.https_cert, cert.cert.pem()).unwrap();
+        }
+
+        println!("Starting HTTPS server on https://{}", addr);
+        let config = RustlsConfig::from_pem_file(&args.https_cert, &args.https_key)
+            .await
+            .expect("failed to load certs");
+        axum_server::bind_rustls(addr, config)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    } else {
+        println!("Starting server on http://{}", addr);
+        axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    }
 }


### PR DESCRIPTION
## Summary
- support HTTPS in server-rs using axum-server and rcgen
- generate self-signed certs when needed
- document new flag

## Testing
- `cargo run -- --help`
- `cargo build --quiet`
- `cargo check --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684fabed4d7883259bfa8c8c259a0944