### PR TITLE
Implement additional CLI params in server-rs

### DIFF
--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -1,13 +1,23 @@
-use axum::{routing::{get, post}, Router, Json};
-use serde::{Deserialize, Serialize};
-use clap::Parser;
-use std::{net::SocketAddr, path::Path};
+use axum::{
+    routing::{get, post},
+    Json, Router,
+};
 use axum_server::tls_rustls::RustlsConfig;
+use clap::Parser;
 use rcgen::generate_simple_self_signed;
+use serde::{Deserialize, Serialize};
+use std::{net::SocketAddr, path::Path};
+
+mod voice_changer_params;
+use voice_changer_params::VoiceChangerParams;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 struct Args {
+    /// Log level
+    #[arg(long, default_value = "error")]
+    log_level: String,
+
     /// Port to listen on
     #[arg(short = 'p', long, default_value_t = 18888)]
     port: u16,
@@ -16,9 +26,17 @@ struct Args {
     #[arg(long, default_value = "127.0.0.1")]
     host: String,
 
+    /// List of allowed origins
+    #[arg(long, value_name = "ORIGIN")]
+    allowed_origins: Vec<String>,
+
     /// Enable HTTPS
     #[arg(long, default_value_t = false)]
     https: bool,
+
+    /// Test connect target (for HTTPS IP detection)
+    #[arg(long, default_value = "8.8.8.8")]
+    test_connect: String,
 
     /// Path to TLS private key
     #[arg(long, default_value = "ssl.key")]
@@ -31,6 +49,50 @@ struct Args {
     /// Generate self-signed certificate when using HTTPS
     #[arg(long, default_value_t = true)]
     https_self_signed: bool,
+
+    /// Path to model directory
+    #[arg(long, default_value = "model_dir")]
+    model_dir: String,
+
+    /// RVC sample mode
+    #[arg(long, default_value = "production")]
+    sample_mode: String,
+
+    #[arg(long, default_value = "pretrain/checkpoint_best_legacy_500.pt")]
+    content_vec_500: String,
+
+    #[arg(long, default_value = "pretrain/content_vec_500.onnx")]
+    content_vec_500_onnx: String,
+
+    #[arg(long, default_value_t = true)]
+    content_vec_500_onnx_on: bool,
+
+    #[arg(long, default_value = "pretrain/hubert_base.pt")]
+    hubert_base: String,
+
+    #[arg(long, default_value = "pretrain/rinna_hubert_base_jp.pt")]
+    hubert_base_jp: String,
+
+    #[arg(long, default_value = "pretrain/hubert/hubert-soft-0d54a1f4.pt")]
+    hubert_soft: String,
+
+    #[arg(long, default_value = "pretrain/whisper_tiny.pt")]
+    whisper_tiny: String,
+
+    #[arg(long, default_value = "pretrain/nsf_hifigan/model")]
+    nsf_hifigan: String,
+
+    #[arg(long, default_value = "pretrain/crepe_onnx_full.onnx")]
+    crepe_onnx_full: String,
+
+    #[arg(long, default_value = "pretrain/crepe_onnx_tiny.onnx")]
+    crepe_onnx_tiny: String,
+
+    #[arg(long, default_value = "pretrain/rmvpe.pt")]
+    rmvpe: String,
+
+    #[arg(long, default_value = "pretrain/rmvpe.onnx")]
+    rmvpe_onnx: String,
 }
 
 #[derive(Serialize)]
@@ -66,6 +128,23 @@ async fn test(Json(payload): Json<VoiceModel>) -> Json<TestResponse> {
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
+
+    let _vc_params = VoiceChangerParams {
+        model_dir: args.model_dir.clone(),
+        content_vec_500: args.content_vec_500.clone(),
+        content_vec_500_onnx: args.content_vec_500_onnx.clone(),
+        content_vec_500_onnx_on: args.content_vec_500_onnx_on,
+        hubert_base: args.hubert_base.clone(),
+        hubert_base_jp: args.hubert_base_jp.clone(),
+        hubert_soft: args.hubert_soft.clone(),
+        nsf_hifigan: args.nsf_hifigan.clone(),
+        sample_mode: args.sample_mode.clone(),
+        crepe_onnx_full: args.crepe_onnx_full.clone(),
+        crepe_onnx_tiny: args.crepe_onnx_tiny.clone(),
+        rmvpe: args.rmvpe.clone(),
+        rmvpe_onnx: args.rmvpe_onnx.clone(),
+        whisper_tiny: args.whisper_tiny.clone(),
+    };
     let app = Router::new()
         .route("/api/hello", get(hello))
         .route("/test", post(test));

--- a/server-rs/src/voice_changer_params.rs
+++ b/server-rs/src/voice_changer_params.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, Clone)]
+pub struct VoiceChangerParams {
+    pub model_dir: String,
+    pub content_vec_500: String,
+    pub content_vec_500_onnx: String,
+    pub content_vec_500_onnx_on: bool,
+    pub hubert_base: String,
+    pub hubert_base_jp: String,
+    pub hubert_soft: String,
+    pub nsf_hifigan: String,
+    pub sample_mode: String,
+    pub crepe_onnx_full: String,
+    pub crepe_onnx_tiny: String,
+    pub rmvpe: String,
+    pub rmvpe_onnx: String,
+    pub whisper_tiny: String,
+}


### PR DESCRIPTION
## Summary
- extend server-rs to parse all parameters from the Python server
- add VoiceChangerParams structure
- instantiate VoiceChangerParams during startup

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684fae4477f08325a5357f6fc9e6f0b2