### PR TITLE
Implement VoiceChangerManager skeleton

### DIFF
--- a/server-rs/Cargo.toml
+++ b/server-rs/Cargo.toml
@@ -4,10 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.6"
+axum = { version = "0.6", features = ["ws"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 axum-server = { version = "0.4", features = ["tls-rustls"] }
 rcgen = "0.13"
+once_cell = "1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+futures-util = "0.3"

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -1,8 +1,9 @@
 # server-rs
 
 This directory contains a minimal Rust reimplementation of `MMVCServerSIO.py`.
-It uses the `tokio` ecosystem and `axum` to provide HTTP endpoints similar to
-the original Python server.
+It uses the `tokio` ecosystem and `axum` to provide HTTP endpoints.  The server
+mirrors the Python layout by exposing a REST API (`MMVC_Rest`) and a simple
+WebSocket endpoint through `MMVC_SocketIOApp`.
 
 ## Requirements
 
@@ -22,7 +23,15 @@ will be generated automatically using a self–signed certificate:
 cargo run -- --https
 ```
 
+Log output can be controlled with the `--log-level` flag (e.g. `info`, `debug`).
+
 After starting, open `http://127.0.0.1:18888/api/hello` in your browser to check
 that the server is running. The `/test` endpoint accepts a JSON payload
 containing `timestamp` and `buffer` fields and echoes them back.
+
+In addition a WebSocket echo service is available at `/ws`.
+
+The server initializes a `VoiceChangerManager` which will manage model
+loading and settings updates. Currently it only provides placeholder
+functionality but mirrors the structure of the Python implementation.
 

--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -1,15 +1,20 @@
-use axum::{
-    routing::{get, post},
-    Json, Router,
-};
 use axum_server::tls_rustls::RustlsConfig;
 use clap::Parser;
 use rcgen::generate_simple_self_signed;
-use serde::{Deserialize, Serialize};
+
 use std::{net::SocketAddr, path::Path};
+use tracing_subscriber::EnvFilter;
 
 mod voice_changer_params;
 use voice_changer_params::VoiceChangerParams;
+mod voice_changer_params_manager;
+use voice_changer_params_manager::VoiceChangerParamsManager;
+mod voice_changer_manager;
+use voice_changer_manager::VoiceChangerManager;
+mod mmvc_rest;
+mod mmvc_socketio_app;
+use mmvc_rest::MMVCRest;
+use mmvc_socketio_app::MMVCSocketIOApp;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -95,41 +100,9 @@ struct Args {
     rmvpe_onnx: String,
 }
 
-#[derive(Serialize)]
-struct Hello {
-    result: &'static str,
-}
 
-async fn hello() -> Json<Hello> {
-    Json(Hello { result: "Index" })
-}
-
-#[derive(Deserialize)]
-struct VoiceModel {
-    timestamp: u64,
-    buffer: String,
-}
-
-#[derive(Serialize)]
-struct TestResponse {
-    timestamp: u64,
-    changed_voice_base64: String,
-}
-
-async fn test(Json(payload): Json<VoiceModel>) -> Json<TestResponse> {
-    // In the Python implementation this would run the voice changer.
-    // Here we simply echo back the input buffer.
-    Json(TestResponse {
-        timestamp: payload.timestamp,
-        changed_voice_base64: payload.buffer,
-    })
-}
-
-#[tokio::main]
-async fn main() {
-    let args = Args::parse();
-
-    let _vc_params = VoiceChangerParams {
+async fn local_server(args: Args) {
+    let vc_params = VoiceChangerParams {
         model_dir: args.model_dir.clone(),
         content_vec_500: args.content_vec_500.clone(),
         content_vec_500_onnx: args.content_vec_500_onnx.clone(),
@@ -145,9 +118,12 @@ async fn main() {
         rmvpe_onnx: args.rmvpe_onnx.clone(),
         whisper_tiny: args.whisper_tiny.clone(),
     };
-    let app = Router::new()
-        .route("/api/hello", get(hello))
-        .route("/test", post(test));
+
+    VoiceChangerParamsManager::get_instance().set_params(vc_params.clone());
+    let _manager = VoiceChangerManager::get_instance(vc_params);
+    let rest = MMVCRest::new();
+    let socket_app = MMVCSocketIOApp::new(rest.router());
+    let app = socket_app.router();
 
     let addr = SocketAddr::new(args.host.parse().unwrap(), args.port);
 
@@ -176,4 +152,13 @@ async fn main() {
             .await
             .unwrap();
     }
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::new(args.log_level.clone()))
+        .init();
+    local_server(args).await;
 }

--- a/server-rs/src/mmvc_rest.rs
+++ b/server-rs/src/mmvc_rest.rs
@@ -1,0 +1,48 @@
+use axum::{routing::{get, post}, Router, Json};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+struct Hello {
+    result: &'static str,
+}
+
+async fn hello() -> Json<Hello> {
+    Json(Hello { result: "Index" })
+}
+
+#[derive(Deserialize)]
+struct VoiceModel {
+    timestamp: u64,
+    buffer: String,
+}
+
+#[derive(Serialize)]
+struct TestResponse {
+    timestamp: u64,
+    changed_voice_base64: String,
+}
+
+async fn test(Json(payload): Json<VoiceModel>) -> Json<TestResponse> {
+    // Placeholder implementation: echo back the payload
+    Json(TestResponse {
+        timestamp: payload.timestamp,
+        changed_voice_base64: payload.buffer,
+    })
+}
+
+pub struct MMVCRest {
+    router: Router,
+}
+
+impl MMVCRest {
+    pub fn new() -> Self {
+        let router = Router::new()
+            .route("/api/hello", get(hello))
+            .route("/test", post(test));
+        Self { router }
+    }
+
+    pub fn router(self) -> Router {
+        self.router
+    }
+}

--- a/server-rs/src/mmvc_socketio_app.rs
+++ b/server-rs/src/mmvc_socketio_app.rs
@@ -1,0 +1,40 @@
+use axum::{routing::get, extract::ws::{WebSocket, WebSocketUpgrade, Message}, Router, response::IntoResponse};
+use futures_util::StreamExt;
+
+async fn ws_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(mut socket: WebSocket) {
+    while let Some(Ok(msg)) = socket.next().await {
+        match msg {
+            Message::Text(text) => {
+                if socket.send(Message::Text(text)).await.is_err() {
+                    return;
+                }
+            }
+            Message::Binary(bin) => {
+                if socket.send(Message::Binary(bin)).await.is_err() {
+                    return;
+                }
+            }
+            Message::Close(_) => return,
+            _ => {}
+        }
+    }
+}
+
+pub struct MMVCSocketIOApp {
+    router: Router,
+}
+
+impl MMVCSocketIOApp {
+    pub fn new(rest_router: Router) -> Self {
+        let router = rest_router.route("/ws", get(ws_handler));
+        Self { router }
+    }
+
+    pub fn router(self) -> Router {
+        self.router
+    }
+}

--- a/server-rs/src/voice_changer_manager.rs
+++ b/server-rs/src/voice_changer_manager.rs
@@ -1,0 +1,105 @@
+use once_cell::sync::OnceCell;
+use serde::Serialize;
+use serde_json::json;
+use std::sync::RwLock;
+
+use crate::voice_changer_params::VoiceChangerParams;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VoiceChangerManagerSettings {
+    pub model_slot_index: i32,
+    pub pass_through: bool,
+}
+
+impl Default for VoiceChangerManagerSettings {
+    fn default() -> Self {
+        Self {
+            model_slot_index: -1,
+            pass_through: false,
+        }
+    }
+}
+
+pub struct VoiceChangerManager {
+    params: VoiceChangerParams,
+    settings: RwLock<VoiceChangerManagerSettings>,
+    model_path: RwLock<Option<String>>,
+    emit_callback: RwLock<Option<Box<dyn Fn(Vec<f32>) + Send + Sync>>>,
+}
+
+static INSTANCE: OnceCell<VoiceChangerManager> = OnceCell::new();
+
+impl VoiceChangerManager {
+    pub fn get_instance(params: VoiceChangerParams) -> &'static VoiceChangerManager {
+        INSTANCE.get_or_init(|| Self {
+            params,
+            settings: RwLock::new(VoiceChangerManagerSettings::default()),
+            model_path: RwLock::new(None),
+            emit_callback: RwLock::new(None),
+        })
+    }
+
+    pub fn load_model(&self, path: String) {
+        let mut guard = self.model_path.write().unwrap();
+        *guard = Some(path);
+    }
+
+    pub fn change_voice(&self, input: &[i16]) -> Vec<i16> {
+        // placeholder implementation just echoes the input
+        input.to_vec()
+    }
+
+    pub fn update_settings(&self, key: &str, val: serde_json::Value) -> serde_json::Value {
+        {
+            let mut settings = self.settings.write().unwrap();
+            match key {
+                "modelSlotIndex" => {
+                    if let Some(v) = val.as_i64() {
+                        settings.model_slot_index = v as i32;
+                    }
+                }
+                "passThrough" => {
+                    if let Some(v) = val.as_bool() {
+                        settings.pass_through = v;
+                    }
+                }
+                _ => {}
+            }
+        }
+        self.get_info()
+    }
+
+    pub fn get_info(&self) -> serde_json::Value {
+        let settings = self.settings.read().unwrap();
+        json!({
+            "status": "OK",
+            "settings": &*settings,
+            "modelPath": self.model_path.read().unwrap().clone(),
+        })
+    }
+
+    pub fn export_to_onnx(&self) -> bool {
+        // placeholder always returns false
+        false
+    }
+
+    pub fn merge_models(&self, _request: &str) -> serde_json::Value {
+        json!({ "status": "OK" })
+    }
+}
+
+impl VoiceChangerManager {
+    pub fn set_emit_to<F>(&self, cb: F)
+    where
+        F: Fn(Vec<f32>) + Send + Sync + 'static,
+    {
+        let mut lock = self.emit_callback.write().unwrap();
+        *lock = Some(Box::new(cb));
+    }
+
+    pub fn emit_performance(&self, perf: Vec<f32>) {
+        if let Some(cb) = &*self.emit_callback.read().unwrap() {
+            cb(perf);
+        }
+    }
+}

--- a/server-rs/src/voice_changer_params_manager.rs
+++ b/server-rs/src/voice_changer_params_manager.rs
@@ -1,0 +1,27 @@
+use once_cell::sync::OnceCell;
+use std::sync::RwLock;
+
+use crate::voice_changer_params::VoiceChangerParams;
+
+pub struct VoiceChangerParamsManager {
+    params: RwLock<Option<VoiceChangerParams>>,
+}
+
+static INSTANCE: OnceCell<VoiceChangerParamsManager> = OnceCell::new();
+
+impl VoiceChangerParamsManager {
+    pub fn get_instance() -> &'static VoiceChangerParamsManager {
+        INSTANCE.get_or_init(|| VoiceChangerParamsManager {
+            params: RwLock::new(None),
+        })
+    }
+
+    pub fn set_params(&self, params: VoiceChangerParams) {
+        let mut guard = self.params.write().unwrap();
+        *guard = Some(params);
+    }
+
+    pub fn params(&self) -> Option<VoiceChangerParams> {
+        self.params.read().unwrap().clone()
+    }
+}


### PR DESCRIPTION
## Summary
- add `VoiceChangerManager` module mirroring Python structure
- initialize the manager during server startup
- document new component in README

## Testing
- `cargo check --manifest-path server-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_684fb050eedc83258bef7df8394fd99e