### PR TITLE
Serve static frontend from Rust server

### DIFF
--- a/server-rs/Cargo.toml
+++ b/server-rs/Cargo.toml
@@ -15,6 +15,8 @@ rcgen = "0.13"
 once_cell = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 futures-util = "0.3"
+tower-http = { version = "0.3", features = ["fs"] }
+reqwest = { version = "0.11", features = ["json"] }
 
 [dev-dependencies]
 tower = "0.4"

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -31,7 +31,12 @@ containing `timestamp` and `buffer` fields and echoes them back.
 
 In addition a WebSocket echo service is available at `/ws`.
 
+Static frontend files from `client/demo/dist` are served at `/`, `/front`,
+`/trainer`, and `/recorder` along with auxiliary directories used by the
+Python implementation.
+
 The server initializes a `VoiceChangerManager` which will manage model
-loading and settings updates. Currently it only provides placeholder
-functionality but mirrors the structure of the Python implementation.
+loading and settings updates. During startup required weight files and
+initial sample models are downloaded automatically if they are missing,
+mirroring the behaviour of the Python implementation.
 

--- a/server-rs/src/constants.rs
+++ b/server-rs/src/constants.rs
@@ -1,0 +1,21 @@
+use std::path::PathBuf;
+
+/// Return the path to the frontend assets directory.
+///
+/// When the `MEIPASS` environment variable is set (used when the
+/// application is packaged similarly to the Python version), the
+/// assets are expected to be located in `MEIPASS/dist`. Otherwise the
+/// default development path `../client/demo/dist` is used.
+pub fn get_frontend_path() -> PathBuf {
+    match std::env::var("MEIPASS") {
+        Ok(p) => PathBuf::from(p).join("dist"),
+        Err(_) => PathBuf::from("../client/demo/dist"),
+    }
+}
+
+/// Directory used for temporary files.
+pub const TMP_DIR: &str = "tmp_dir";
+/// Directory used for uploaded files.
+pub const UPLOAD_DIR: &str = "upload_dir";
+/// Directory containing static models.
+pub const MODEL_DIR_STATIC: &str = "model_dir_static";

--- a/server-rs/src/downloader.rs
+++ b/server-rs/src/downloader.rs
@@ -1,0 +1,156 @@
+use std::path::{Path, PathBuf};
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::voice_changer_params::VoiceChangerParams;
+
+pub async fn download_file(client: &Client, url: &str, save_to: &Path) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if let Some(parent) = save_to.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let bytes = client.get(url).send().await?.bytes().await?;
+    tokio::fs::write(save_to, &bytes).await?;
+    Ok(())
+}
+
+pub async fn download_weight(params: &VoiceChangerParams) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let client = Client::new();
+    let mut tasks = Vec::new();
+
+    let mappings = vec![
+        (&params.hubert_base as &str, "https://huggingface.co/ddPn08/rvc-webui-models/resolve/main/embeddings/hubert_base.pt"),
+        (&params.hubert_base_jp as &str, "https://huggingface.co/rinna/japanese-hubert-base/resolve/main/fairseq/model.pt"),
+        (&params.hubert_soft as &str, "https://huggingface.co/wok000/weights/resolve/main/ddsp-svc30/embedder/hubert-soft-0d54a1f4.pt"),
+        (&params.nsf_hifigan as &str, "https://huggingface.co/wok000/weights/resolve/main/ddsp-svc30/nsf_hifigan_20221211/model.bin"),
+        (&params.crepe_onnx_full as &str, "https://huggingface.co/wok000/weights/resolve/main/crepe/onnx/full.onnx"),
+        (&params.crepe_onnx_tiny as &str, "https://huggingface.co/wok000/weights/resolve/main/crepe/onnx/tiny.onnx"),
+        (&params.content_vec_500_onnx as &str, "https://huggingface.co/wok000/weights_gpl/resolve/main/content-vec/contentvec-f.onnx"),
+        (&params.rmvpe as &str, "https://huggingface.co/wok000/weights/resolve/main/rmvpe/rmvpe_20231006.pt"),
+        (&params.rmvpe_onnx as &str, "https://huggingface.co/wok000/weights_gpl/resolve/main/rmvpe/rmvpe_20231006.onnx"),
+        (&params.whisper_tiny as &str, "https://openaipublic.azureedge.net/main/whisper/models/65147644a518d12f04e32d6f3b26facc3f8dd46e5390956a9424a650c0ce22b9/tiny.pt"),
+    ];
+
+    for (path, url) in mappings {
+        if !Path::new(path).exists() {
+            let p = PathBuf::from(path);
+            let u = url.to_string();
+            let client = client.clone();
+            tasks.push(tokio::spawn(async move { download_file(&client, &u, &p).await }));
+        }
+    }
+
+    // additional files relative to nsf_hifigan
+    if !Path::new(&params.nsf_hifigan).exists() {
+        let config_path = PathBuf::from(&params.nsf_hifigan).with_file_name("config.json");
+        let onnx_path = PathBuf::from(&params.nsf_hifigan).with_file_name("nsf_hifigan.onnx");
+        if !config_path.exists() {
+            let client = client.clone();
+            let cp = config_path.clone();
+            tasks.push(tokio::spawn(async move {
+                download_file(
+                    &client,
+                    "https://huggingface.co/wok000/weights/raw/main/ddsp-svc30/nsf_hifigan_20221211/config.json",
+                    &cp,
+                )
+                .await
+            }));
+        }
+        if !onnx_path.exists() {
+            let client = client.clone();
+            let op = onnx_path.clone();
+            tasks.push(tokio::spawn(async move {
+                download_file(
+                    &client,
+                    "https://huggingface.co/wok000/weights/resolve/main/ddsp-svc30/nsf_hifigan_onnx_20221211/nsf_hifigan.onnx",
+                    &op,
+                )
+                .await
+            }));
+        }
+    }
+
+    for t in tasks {
+        t.await??;
+    }
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct SampleModelParam {
+    use_index: bool,
+}
+
+struct Sample {
+    id: String,
+    model_url: String,
+    index_url: Option<String>,
+    icon: Option<String>,
+}
+
+pub async fn download_initial_samples(mode: &str, model_dir: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if tokio::fs::metadata(model_dir).await.is_ok() {
+        println!("[Voice Changer] model_dir already exists. skip download samples.");
+        return Ok(());
+    }
+
+    let (json_urls, sample_models) = get_sample_json_and_model_ids(mode);
+    let client = Client::new();
+    let mut samples: Vec<Sample> = Vec::new();
+
+    for url in json_urls {
+        let text = client.get(url).send().await?.text().await?;
+        let v: Value = serde_json::from_str(&text)?;
+        for arr in v.as_object().unwrap().values() {
+            if let Some(list) = arr.as_array() {
+                for item in list {
+                    let id = item["id"].as_str().unwrap().to_string();
+                    let model_url = item["modelUrl"].as_str().unwrap().to_string();
+                    let index_url = item.get("indexUrl").and_then(|v| v.as_str()).map(|s| s.to_string());
+                    let icon = item.get("icon").and_then(|v| v.as_str()).map(|s| s.to_string());
+                    samples.push(Sample { id, model_url, index_url, icon });
+                }
+            }
+        }
+    }
+
+    for (i, (sample_id, param)) in sample_models.iter().enumerate() {
+        if let Some(sample) = samples.iter().find(|s| &s.id == sample_id) {
+            let slot_dir = Path::new(model_dir).join(i.to_string());
+            tokio::fs::create_dir_all(&slot_dir).await?;
+            let model_path = slot_dir.join(Path::new(&sample.model_url).file_name().unwrap());
+            download_file(&client, &sample.model_url, &model_path).await?;
+            if param.use_index {
+                if let Some(index_url) = &sample.index_url {
+                    let index_path = slot_dir.join(Path::new(index_url).file_name().unwrap());
+                    download_file(&client, index_url, &index_path).await?;
+                }
+            }
+            if let Some(icon) = &sample.icon {
+                let icon_path = slot_dir.join(Path::new(icon).file_name().unwrap());
+                download_file(&client, icon, &icon_path).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn get_sample_json_and_model_ids(mode: &str) -> (Vec<&'static str>, Vec<(&'static str, SampleModelParam)>) {
+    match mode {
+        "production" => (
+            vec![
+                "https://huggingface.co/wok000/vcclient_model/raw/main/samples_0004_t.json",
+                "https://huggingface.co/wok000/vcclient_model/raw/main/samples_0004_o.json",
+                "https://huggingface.co/wok000/vcclient_model/raw/main/samples_0004_d.json",
+            ],
+            vec![
+                ("Tsukuyomi-chan_o", SampleModelParam { use_index: false }),
+                ("Amitaro_o", SampleModelParam { use_index: false }),
+                ("KikotoMahiro_o", SampleModelParam { use_index: false }),
+                ("TokinaShigure_o", SampleModelParam { use_index: false }),
+            ],
+        ),
+        _ => (Vec::new(), Vec::new()),
+    }
+}

--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -16,6 +16,9 @@ mod mmvc_socketio_app;
 mod mmvc_socketio_server;
 use mmvc_rest::MMVCRest;
 use mmvc_socketio_app::MMVCSocketIOApp;
+mod downloader;
+use downloader::{download_initial_samples, download_weight};
+mod constants;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -119,6 +122,14 @@ async fn local_server(args: Args) {
         rmvpe_onnx: args.rmvpe_onnx.clone(),
         whisper_tiny: args.whisper_tiny.clone(),
     };
+
+    // download required weights and sample models
+    if let Err(e) = download_weight(&vc_params).await {
+        eprintln!("failed to download weights: {e}");
+    }
+    if let Err(e) = download_initial_samples(&args.sample_mode, &args.model_dir).await {
+        eprintln!("failed to download samples: {e}");
+    }
 
     VoiceChangerParamsManager::get_instance().set_params(vc_params.clone());
     let manager = VoiceChangerManager::get_instance(vc_params.clone());

--- a/server-rs/src/mmvc_socketio_app.rs
+++ b/server-rs/src/mmvc_socketio_app.rs
@@ -1,8 +1,15 @@
-use axum::Router;
+use axum::{
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get_service,
+    Router,
+};
+use tower_http::services::ServeDir;
 
 use crate::{
     voice_changer_manager::VoiceChangerManager,
     mmvc_socketio_server::MMVCSocketIOServer,
+    constants::{get_frontend_path, TMP_DIR, UPLOAD_DIR, MODEL_DIR_STATIC},
 };
 
 pub struct MMVCSocketIOApp {
@@ -12,7 +19,34 @@ pub struct MMVCSocketIOApp {
 impl MMVCSocketIOApp {
     pub fn new(rest_router: Router, manager: &'static VoiceChangerManager) -> Self {
         let socket_router = MMVCSocketIOServer::new(manager).router();
-        let router = rest_router.merge(socket_router);
+
+        // static file serving similar to the Python implementation
+        let frontend = get_frontend_path();
+        let serve_front = |dir: std::path::PathBuf| {
+            get_service(ServeDir::new(dir).append_index_html_on_directories(true))
+                .handle_error(|_| async { StatusCode::INTERNAL_SERVER_ERROR.into_response() })
+        };
+
+        let router = rest_router
+            .merge(socket_router)
+            .nest_service("/front", serve_front(frontend.clone()))
+            .nest_service("/trainer", serve_front(frontend.clone()))
+            .nest_service("/recorder", serve_front(frontend.clone()))
+            .nest_service(
+                format!("/{}", manager.model_dir()).as_str(),
+                serve_front(std::path::PathBuf::from(manager.model_dir())),
+            )
+            .nest_service("/tmp", serve_front(std::path::PathBuf::from(TMP_DIR)))
+            .nest_service(
+                "/upload_dir",
+                serve_front(std::path::PathBuf::from(UPLOAD_DIR)),
+            )
+            .nest_service(
+                "/model_dir_static",
+                serve_front(std::path::PathBuf::from(MODEL_DIR_STATIC)),
+            )
+            .fallback_service(serve_front(frontend));
+
         Self { router }
     }
 

--- a/server-rs/src/voice_changer_manager.rs
+++ b/server-rs/src/voice_changer_manager.rs
@@ -39,6 +39,10 @@ impl VoiceChangerManager {
         })
     }
 
+    pub fn model_dir(&self) -> &str {
+        &self.params.model_dir
+    }
+
     pub fn load_model(&self, path: String) {
         let mut guard = self.model_path.write().unwrap();
         *guard = Some(path);


### PR DESCRIPTION
## Summary
- add tower-http dependency
- expose `get_frontend_path` helper and related constants
- serve frontend and asset directories in Rust socket app
- expose model directory path from manager
- document static serving behaviour in README
- add weight and sample download in Rust implementation

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_684fcebed6b48325ac25d5b486f6bc03