### PR TITLE
Improve RVC struct

### DIFF
--- a/server-rs/Cargo.toml
+++ b/server-rs/Cargo.toml
@@ -23,3 +23,4 @@ tower = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 tokio-tungstenite = "0.21"
 tempfile = "3"
+serial_test = "2"

--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -7,14 +7,15 @@ use tracing_subscriber::EnvFilter;
 
 mod voice_changer_params;
 use voice_changer_params::VoiceChangerParams;
-mod voice_changer;
-mod rvc;
-mod plugin;
 mod model_slot;
+mod plugin;
+mod rvc;
+mod voice_changer;
 mod voice_changer_params_manager;
 use voice_changer_params_manager::VoiceChangerParamsManager;
 mod voice_changer_manager;
 use voice_changer_manager::VoiceChangerManager;
+mod volume_extractor;
 mod mmvc_rest;
 mod mmvc_socketio_app;
 mod mmvc_socketio_server;
@@ -107,7 +108,6 @@ struct Args {
     #[arg(long, default_value = "pretrain/rmvpe.onnx")]
     rmvpe_onnx: String,
 }
-
 
 async fn local_server(args: Args) {
     let vc_params = VoiceChangerParams {

--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -15,15 +15,17 @@ mod voice_changer_params_manager;
 use voice_changer_params_manager::VoiceChangerParamsManager;
 mod voice_changer_manager;
 use voice_changer_manager::VoiceChangerManager;
-mod volume_extractor;
 mod mmvc_rest;
 mod mmvc_socketio_app;
 mod mmvc_socketio_server;
+mod volume_extractor;
 use mmvc_rest::MMVCRest;
 use mmvc_socketio_app::MMVCSocketIOApp;
 mod downloader;
 use downloader::{download_initial_samples, download_weight};
 mod constants;
+#[cfg(test)]
+mod test_util;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]

--- a/server-rs/src/mmvc_rest.rs
+++ b/server-rs/src/mmvc_rest.rs
@@ -120,8 +120,10 @@ mod tests {
     use serde_json::{json, Value};
     use tower::ServiceExt; // for `oneshot`
 
+    use crate::test_util::cleanup_test_dirs;
     use crate::voice_changer_params::VoiceChangerParams;
-    fn app() -> Router {
+    use serial_test::serial;
+    fn app() -> (Router, &'static VoiceChangerManager) {
         let params = VoiceChangerParams {
             model_dir: "m".into(),
             content_vec_500: "".into(),
@@ -141,12 +143,13 @@ mod tests {
         let manager = VoiceChangerManager::get_instance(params);
         #[cfg(test)]
         manager.reset();
-        MMVCRest::new(manager).router()
+        (MMVCRest::new(manager).router(), manager)
     }
 
     #[tokio::test]
+    #[serial]
     async fn hello_endpoint_returns_index() {
-        let app = app();
+        let (app, manager) = app();
         let response = app
             .oneshot(
                 Request::builder()
@@ -162,11 +165,14 @@ mod tests {
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["result"], "Index");
+        manager.reset();
+        cleanup_test_dirs();
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_endpoint_echoes_payload() {
-        let app = app();
+        let (app, manager) = app();
         let samples = vec![1i16, -2i16];
         let bytes: Vec<u8> = samples.iter().flat_map(|x| x.to_le_bytes()).collect();
         let encoded = general_purpose::STANDARD.encode(&bytes);
@@ -188,5 +194,7 @@ mod tests {
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["timestamp"], 123);
         assert_eq!(v["changed_voice_base64"], encoded);
+        manager.reset();
+        cleanup_test_dirs();
     }
 }

--- a/server-rs/src/mmvc_rest.rs
+++ b/server-rs/src/mmvc_rest.rs
@@ -1,3 +1,10 @@
+//! REST API exposing a minimal set of voice changer endpoints.
+//!
+//! This module implements a subset of the Python server REST API.  The
+//! endpoints are primarily used for unit testing and as a simple example for
+//! clients.  Each handler is documented so `cargo doc` can generate API
+//! documentation for the HTTP routes.
+
 use axum::{
     routing::{get, post},
     Json, Router,
@@ -15,27 +22,41 @@ use tokio::sync::Mutex;
 static MANAGER: OnceCell<&'static VoiceChangerManager> = OnceCell::new();
 static LOCK: OnceCell<Arc<Mutex<()>>> = OnceCell::new();
 
+/// Response for [`hello`] endpoint.
 #[derive(Serialize)]
 struct Hello {
+    /// Static greeting string returned to the client.
     result: &'static str,
 }
 
+/// `GET /api/hello`
+///
+/// Return a simple greeting verifying that the server is running.
 async fn hello() -> Json<Hello> {
     Json(Hello { result: "Index" })
 }
 
+/// Request payload for [`test()`] endpoint.
 #[derive(Deserialize)]
 struct VoiceModel {
+    /// Arbitrary timestamp used by the caller.
     timestamp: u64,
+    /// Little endian 16‑bit PCM samples encoded as base64.
     buffer: String,
 }
 
+/// Response payload for [`test()`].
 #[derive(Serialize)]
 struct TestResponse {
+    /// Echoed timestamp from the request.
     timestamp: u64,
+    /// Converted voice samples encoded as base64.
     changed_voice_base64: String,
 }
 
+/// `POST /test`
+///
+/// Accepts base64 encoded audio samples and returns the modified voice.
 async fn test(Json(payload): Json<VoiceModel>) -> Json<TestResponse> {
     let manager = MANAGER.get().expect("manager not set");
     let lock = LOCK.get().expect("lock not set");
@@ -61,11 +82,16 @@ async fn test(Json(payload): Json<VoiceModel>) -> Json<TestResponse> {
     })
 }
 
+/// REST API application.
+///
+/// Use [`MMVCRest::new`] to create a router that exposes the HTTP endpoints
+/// defined in this module.
 pub struct MMVCRest {
     router: Router,
 }
 
 impl MMVCRest {
+    /// Construct a new [`MMVCRest`] using the provided manager instance.
     pub fn new(manager: &'static VoiceChangerManager) -> Self {
         MANAGER.set(manager).ok();
         LOCK.set(Arc::new(Mutex::new(()))).ok();
@@ -77,6 +103,7 @@ impl MMVCRest {
         Self { router }
     }
 
+    /// Consume the object and return the underlying [`Router`].
     pub fn router(self) -> Router {
         self.router
     }

--- a/server-rs/src/mmvc_rest_fileuploader.rs
+++ b/server-rs/src/mmvc_rest_fileuploader.rs
@@ -1,3 +1,9 @@
+//! File upload and model management REST API.
+//!
+//! This module contains handlers roughly corresponding to the Python
+//! implementation.  They are intentionally simple and documented so that
+//! generated documentation can describe the available endpoints.
+
 use axum::{
     extract::{Form, Multipart},
     routing::{get, post},
@@ -11,11 +17,14 @@ use tokio::{fs, io::AsyncWriteExt};
 
 use crate::voice_changer_manager::VoiceChangerManager;
 
+/// Directory used for temporarily storing uploaded chunks.
 const UPLOAD_DIR: &str = "upload_dir";
+/// Directory containing saved models.
 const MODEL_DIR: &str = "logs";
 
 static MANAGER: OnceCell<&'static VoiceChangerManager> = OnceCell::new();
 
+/// Remove any directory components from user provided file names.
 fn sanitize_filename(filename: &str) -> String {
     Path::new(filename)
         .file_name()
@@ -24,6 +33,10 @@ fn sanitize_filename(filename: &str) -> String {
         .to_string()
 }
 
+/// `POST /upload_file`
+///
+/// Accept a multipart request containing a file and store it in
+/// [`UPLOAD_DIR`].  The form fields `filename` and `file` are expected.
 async fn post_upload_file(mut multipart: Multipart) -> Json<Value> {
     let mut filename: Option<String> = None;
     let mut file_bytes: Option<Vec<u8>> = None;
@@ -65,10 +78,15 @@ async fn post_upload_file(mut multipart: Multipart) -> Json<Value> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ConcatParams {
+    /// Name of the final file to create.
     filename: String,
+    /// Number of chunks that were uploaded.
     filename_chunk_num: usize,
 }
 
+/// `POST /concat_uploaded_file`
+///
+/// Combine previously uploaded chunks into a single file.
 async fn post_concat_uploaded_file(Form(params): Form<ConcatParams>) -> Json<Value> {
     let safe_name = sanitize_filename(&params.filename);
     let target = PathBuf::from(UPLOAD_DIR).join(&safe_name);
@@ -101,11 +119,17 @@ async fn post_concat_uploaded_file(Form(params): Form<ConcatParams>) -> Json<Val
     Json(json!({"status":"OK","msg":format!("concat files {}", safe_name)}))
 }
 
+/// `GET /info`
+///
+/// Return current server information, mirroring the Python API.
 async fn get_info() -> Json<Value> {
     let manager = MANAGER.get().expect("manager not set");
     Json(manager.get_info())
 }
 
+/// `GET /performance`
+///
+/// Return performance counters for the current model.
 async fn get_performance() -> Json<Value> {
     let manager = MANAGER.get().expect("manager not set");
     Json(manager.get_performance())
@@ -113,10 +137,15 @@ async fn get_performance() -> Json<Value> {
 
 #[derive(Deserialize)]
 struct UpdateParams {
+    /// Setting key to update.
     key: String,
+    /// New value as JSON or plain string.
     val: String,
 }
 
+/// `POST /update_settings`
+///
+/// Update global settings by key.
 async fn post_update_settings(Form(params): Form<UpdateParams>) -> Json<Value> {
     let manager = MANAGER.get().expect("manager not set");
     let val: Value = serde_json::from_str(&params.val).unwrap_or(Value::String(params.val));
@@ -126,14 +155,22 @@ async fn post_update_settings(Form(params): Form<UpdateParams>) -> Json<Value> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct LoadModelPayload {
+    /// Target slot index.
     slot: i32,
+    /// Whether to load the model using half precision.
     is_half: bool,
+    /// Additional JSON parameters.
     params: String,
 }
 
+/// `POST /load_model`
+///
+/// Load a voice model based on uploaded assets.
 async fn post_load_model(Form(payload): Form<LoadModelPayload>) -> Json<Value> {
     let manager = MANAGER.get().expect("manager not set");
-    if let Ok(req) = serde_json::from_str::<crate::voice_changer_manager::LoadModelRequest>(&payload.params) {
+    if let Ok(req) =
+        serde_json::from_str::<crate::voice_changer_manager::LoadModelRequest>(&payload.params)
+    {
         Json(manager.load_model(req))
     } else {
         Json(json!({"status": "ERROR", "msg": "invalid params"}))
@@ -142,19 +179,29 @@ async fn post_load_model(Form(payload): Form<LoadModelPayload>) -> Json<Value> {
 
 #[derive(Deserialize)]
 struct MergeParams {
+    /// JSON request string describing the merge.
     request: String,
 }
 
+/// `POST /merge_model`
+///
+/// Merge two models according to the provided request.
 async fn post_merge_models(Form(params): Form<MergeParams>) -> Json<Value> {
     let manager = MANAGER.get().expect("manager not set");
     Json(manager.merge_models(&params.request))
 }
 
+/// `GET /onnx`
+///
+/// Export the current model to ONNX format if possible.
 async fn get_onnx() -> Json<Value> {
     let manager = MANAGER.get().expect("manager not set");
     Json(json!({"exported": manager.export_to_onnx()}))
 }
 
+/// `POST /update_model_default`
+///
+/// Update the default model configuration.
 async fn post_update_model_default() -> Json<Value> {
     let manager = MANAGER.get().expect("manager not set");
     Json(manager.update_model_default())
@@ -163,9 +210,13 @@ async fn post_update_model_default() -> Json<Value> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateModelInfo {
+    /// JSON metadata to write.
     new_data: String,
 }
 
+/// `POST /update_model_info`
+///
+/// Write metadata to the current model slot.
 async fn post_update_model_info(Form(params): Form<UpdateModelInfo>) -> Json<Value> {
     let manager = MANAGER.get().expect("manager not set");
     Json(manager.update_model_info(&params.new_data))
@@ -173,19 +224,25 @@ async fn post_update_model_info(Form(params): Form<UpdateModelInfo>) -> Json<Val
 
 #[derive(Deserialize)]
 struct UploadModelAssets {
+    /// JSON request describing the asset move.
     params: String,
 }
 
+/// `POST /upload_model_assets`
+///
+/// Move uploaded model assets into the selected slot.
 async fn post_upload_model_assets(Form(params): Form<UploadModelAssets>) -> Json<Value> {
     let manager = MANAGER.get().expect("manager not set");
     Json(manager.upload_model_assets(&params.params))
 }
 
+/// Sub-router providing file upload and model management endpoints.
 pub struct MMVCRestFileuploader {
     router: Router,
 }
 
 impl MMVCRestFileuploader {
+    /// Create a new instance configured with a [`VoiceChangerManager`].
     pub fn new(manager: &'static VoiceChangerManager) -> Self {
         MANAGER.set(manager).ok();
         let router = Router::new()
@@ -203,6 +260,7 @@ impl MMVCRestFileuploader {
         Self { router }
     }
 
+    /// Consume the object and return the configured [`Router`].
     pub fn router(self) -> Router {
         self.router
     }
@@ -284,5 +342,139 @@ mod tests {
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["settings"]["model_slot_index"], 1);
+    }
+
+    #[tokio::test]
+    async fn performance_endpoint_returns_values() {
+        let app = app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/performance")
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "OK");
+        assert!(v["performance"].as_array().unwrap().len() >= 3);
+    }
+
+    #[tokio::test]
+    async fn onnx_endpoint_exports_model() {
+        let app = app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/onnx")
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert!(v["exported"].as_bool().unwrap());
+    }
+
+    #[tokio::test]
+    async fn upload_and_concat_files() {
+        use hyper::header::{HeaderValue, CONTENT_TYPE};
+        let app = app();
+
+        let boundary = "BOUNDARY";
+        // upload first chunk
+        let body = format!(
+            "--{b}\r\nContent-Disposition: form-data; name=\"filename\"\r\n\r\nfinal.txt_0\r\n--{b}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"final.txt_0\"\r\nContent-Type: application/octet-stream\r\n\r\nhello\r\n--{b}--\r\n",
+            b = boundary
+        );
+        let req = Request::builder()
+            .uri("/upload_file")
+            .method("POST")
+            .header(
+                CONTENT_TYPE,
+                HeaderValue::from_str(&format!("multipart/form-data; boundary={}", boundary))
+                    .unwrap(),
+            )
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // upload second chunk
+        let body = format!(
+            "--{b}\r\nContent-Disposition: form-data; name=\"filename\"\r\n\r\nfinal.txt_1\r\n--{b}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"final.txt_1\"\r\nContent-Type: application/octet-stream\r\n\r\nworld\r\n--{b}--\r\n",
+            b = boundary
+        );
+        let req = Request::builder()
+            .uri("/upload_file")
+            .method("POST")
+            .header(
+                CONTENT_TYPE,
+                HeaderValue::from_str(&format!("multipart/form-data; boundary={}", boundary))
+                    .unwrap(),
+            )
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // concat chunks
+        let payload = "filename=final.txt&filenameChunkNum=2";
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/concat_uploaded_file")
+                    .method("POST")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(payload))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let target = std::path::Path::new(UPLOAD_DIR).join("final.txt");
+        let content = tokio::fs::read_to_string(&target).await.unwrap();
+        assert_eq!(content, "helloworld");
+    }
+
+    #[tokio::test]
+    async fn merge_model_endpoint_creates_file() {
+        use serde_json::json;
+        let app = app();
+        let f1 = std::path::Path::new(crate::constants::TMP_DIR).join("ma.txt");
+        let f2 = std::path::Path::new(crate::constants::TMP_DIR).join("mb.txt");
+        tokio::fs::create_dir_all(crate::constants::TMP_DIR)
+            .await
+            .unwrap();
+        tokio::fs::write(&f1, b"a").await.unwrap();
+        tokio::fs::write(&f2, b"b").await.unwrap();
+        let req = json!({
+            "output": "res.txt",
+            "files": [f1.to_str().unwrap(), f2.to_str().unwrap()]
+        });
+        let payload = format!("request={}", req.to_string());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/merge_model")
+                    .method("POST")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body(Body::from(payload))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let out = std::path::Path::new(crate::constants::TMP_DIR).join("res.txt");
+        assert!(out.exists());
+        let content = tokio::fs::read_to_string(&out).await.unwrap();
+        assert_eq!(content, "ab");
     }
 }

--- a/server-rs/src/mmvc_rest_fileuploader.rs
+++ b/server-rs/src/mmvc_rest_fileuploader.rs
@@ -278,9 +278,11 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::mmvc_rest::MMVCRest;
+    use crate::test_util::cleanup_test_dirs;
     use crate::voice_changer_params::VoiceChangerParams; // for constructing manager
+    use serial_test::serial;
 
-    fn app() -> Router {
+    fn app() -> (Router, &'static VoiceChangerManager) {
         let params = VoiceChangerParams {
             model_dir: "m".into(),
             content_vec_500: "".into(),
@@ -300,12 +302,13 @@ mod tests {
         let manager = VoiceChangerManager::get_instance(params);
         #[cfg(test)]
         manager.reset();
-        MMVCRestFileuploader::new(manager).router()
+        (MMVCRestFileuploader::new(manager).router(), manager)
     }
 
     #[tokio::test]
+    #[serial]
     async fn info_endpoint_returns_status() {
-        let app = app();
+        let (app, manager) = app();
         let response = app
             .oneshot(
                 Request::builder()
@@ -321,11 +324,14 @@ mod tests {
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["status"], "OK");
+        manager.reset();
+        cleanup_test_dirs();
     }
 
     #[tokio::test]
+    #[serial]
     async fn update_settings_endpoint_changes_value() {
-        let app = app();
+        let (app, manager) = app();
         let payload = "key=modelSlotIndex&val=1";
         let response = app
             .oneshot(
@@ -342,11 +348,14 @@ mod tests {
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["settings"]["model_slot_index"], 1);
+        manager.reset();
+        cleanup_test_dirs();
     }
 
     #[tokio::test]
+    #[serial]
     async fn performance_endpoint_returns_values() {
-        let app = app();
+        let (app, manager) = app();
         let response = app
             .oneshot(
                 Request::builder()
@@ -362,11 +371,14 @@ mod tests {
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["status"], "OK");
         assert!(v["performance"].as_array().unwrap().len() >= 3);
+        manager.reset();
+        cleanup_test_dirs();
     }
 
     #[tokio::test]
+    #[serial]
     async fn onnx_endpoint_exports_model() {
-        let app = app();
+        let (app, manager) = app();
         let response = app
             .oneshot(
                 Request::builder()
@@ -381,12 +393,15 @@ mod tests {
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert!(v["exported"].as_bool().unwrap());
+        manager.reset();
+        cleanup_test_dirs();
     }
 
     #[tokio::test]
+    #[serial]
     async fn upload_and_concat_files() {
         use hyper::header::{HeaderValue, CONTENT_TYPE};
-        let app = app();
+        let (app, manager) = app();
 
         let boundary = "BOUNDARY";
         // upload first chunk
@@ -442,12 +457,15 @@ mod tests {
         let target = std::path::Path::new(UPLOAD_DIR).join("final.txt");
         let content = tokio::fs::read_to_string(&target).await.unwrap();
         assert_eq!(content, "helloworld");
+        manager.reset();
+        cleanup_test_dirs();
     }
 
     #[tokio::test]
+    #[serial]
     async fn merge_model_endpoint_creates_file() {
         use serde_json::json;
-        let app = app();
+        let (app, manager) = app();
         let f1 = std::path::Path::new(crate::constants::TMP_DIR).join("ma.txt");
         let f2 = std::path::Path::new(crate::constants::TMP_DIR).join("mb.txt");
         tokio::fs::create_dir_all(crate::constants::TMP_DIR)
@@ -476,5 +494,7 @@ mod tests {
         assert!(out.exists());
         let content = tokio::fs::read_to_string(&out).await.unwrap();
         assert_eq!(content, "ab");
+        manager.reset();
+        cleanup_test_dirs();
     }
 }

--- a/server-rs/src/mmvc_socketio_server.rs
+++ b/server-rs/src/mmvc_socketio_server.rs
@@ -115,6 +115,7 @@ mod tests {
     use axum::Router;
     use futures_util::StreamExt;
     use serde_json::{json, Value};
+    use serial_test::serial;
     use tokio_tungstenite::connect_async;
     use tokio_tungstenite::tungstenite::Message as WsMessage;
 
@@ -135,7 +136,8 @@ mod tests {
         addr
     }
 
-    fn app() -> Router {
+    use crate::test_util::cleanup_test_dirs;
+    fn app() -> (Router, &'static VoiceChangerManager) {
         let params = VoiceChangerParams {
             model_dir: "m".into(),
             content_vec_500: "".into(),
@@ -155,12 +157,13 @@ mod tests {
         let manager = VoiceChangerManager::get_instance(params);
         #[cfg(test)]
         manager.reset();
-        MMVCSocketIOServer::new(manager).router()
+        (MMVCSocketIOServer::new(manager).router(), manager)
     }
 
     #[tokio::test]
+    #[serial]
     async fn websocket_returns_changed_voice() {
-        let app = app();
+        let (app, manager) = app();
         let addr = start_server(app).await;
         let url = format!("ws://{}/ws", addr);
         let (mut ws_stream, _) = connect_async(url).await.unwrap();
@@ -178,5 +181,8 @@ mod tests {
         } else {
             panic!("no response");
         }
+
+        manager.reset();
+        cleanup_test_dirs();
     }
 }

--- a/server-rs/src/model_slot.rs
+++ b/server-rs/src/model_slot.rs
@@ -1,4 +1,12 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+use crate::constants::UPLOAD_DIR;
+/// Maximum number of dynamic model slots.
+const MAX_SLOT_NUM: usize = 10;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ModelSlot {
@@ -19,5 +27,221 @@ impl Default for RVCModelSlot {
             model_file: String::new(),
             sampling_rate: 48000,
         }
+    }
+}
+
+pub struct ModelSlotManager {
+    model_dir: String,
+    slots: RwLock<Vec<ModelSlot>>, 
+}
+
+impl ModelSlotManager {
+    pub fn new(model_dir: String) -> Self {
+        let mgr = Self {
+            model_dir,
+            slots: RwLock::new(Vec::new()),
+        };
+        mgr.reload_slots();
+        mgr
+    }
+
+    fn reload_slots(&self) {
+        let mut vec = Vec::new();
+        for i in 0..MAX_SLOT_NUM {
+            vec.push(self.load_model_slot(i).unwrap_or(ModelSlot::Empty));
+        }
+        if let Ok(mut guard) = self.slots.write() {
+            *guard = vec;
+        }
+    }
+
+    fn slot_path(&self, slot: usize) -> PathBuf {
+        Path::new(&self.model_dir).join(slot.to_string())
+    }
+
+    pub fn save_model_slot(&self, slot: usize, info: &ModelSlot) -> std::io::Result<()> {
+        let dir = self.slot_path(slot);
+        fs::create_dir_all(&dir)?;
+        let path = dir.join("params.json");
+        let text = serde_json::to_string(info).unwrap();
+        fs::write(path, text)?;
+        if let Ok(mut slots) = self.slots.write() {
+            if slot >= slots.len() {
+                slots.resize(slot + 1, ModelSlot::Empty);
+            }
+            if let Some(s) = slots.get_mut(slot) {
+                *s = info.clone();
+            }
+        }
+        Ok(())
+    }
+
+    pub fn load_model_slot(&self, slot: usize) -> Option<ModelSlot> {
+        let path = self.slot_path(slot).join("params.json");
+        let text = fs::read_to_string(path).ok()?;
+        serde_json::from_str(&text).ok()
+    }
+
+    pub fn update_model_info(&self, new_data: &str) -> std::io::Result<()> {
+        let v: Value = serde_json::from_str(new_data)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let slot = v
+            .get("slot")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "slot missing"))?
+            as usize;
+        let key = v
+            .get("key")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "key missing"))?;
+        let val = v.get("val").cloned().unwrap_or(Value::Null);
+        let mut info = self.load_model_slot(slot).unwrap_or(ModelSlot::Empty);
+        match &mut info {
+            ModelSlot::RVC(r) => match key {
+                "modelFile" | "model_file" => {
+                    if let Some(s) = val.as_str() {
+                        r.model_file = s.to_string();
+                    }
+                }
+                "samplingRate" | "sampling_rate" => {
+                    if let Some(n) = val.as_i64() {
+                        r.sampling_rate = n as i32;
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+        self.save_model_slot(slot, &info)?;
+        self.reload_slots();
+        Ok(())
+    }
+
+    pub fn store_model_assets(&self, params: &str) -> std::io::Result<()> {
+        let v: Value = serde_json::from_str(params)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let slot = v
+            .get("slot")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "slot missing"))?
+            as usize;
+        let file = v
+            .get("file")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "file missing"))?;
+        let name = v
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "name missing"))?;
+        let src = Path::new(UPLOAD_DIR).join(file);
+        let dst_dir = self.slot_path(slot);
+        fs::create_dir_all(&dst_dir)?;
+        let dst = dst_dir.join(file);
+        if fs::rename(&src, &dst).is_err() {
+            fs::copy(&src, &dst)?;
+            let _ = fs::remove_file(&src);
+        }
+        let mut info = self.load_model_slot(slot).unwrap_or(ModelSlot::Empty);
+        match &mut info {
+            ModelSlot::RVC(r) => match name {
+                "modelFile" | "model_file" => r.model_file = file.to_string(),
+                "indexFile" | "index_file" => r.model_file = file.to_string(),
+                _ => {}
+            },
+            _ => {}
+        }
+        self.save_model_slot(slot, &info)?;
+        self.reload_slots();
+        Ok(())
+    }
+
+    /// Return all slot information, optionally reloading from disk.
+    pub fn get_all_slot_info(&self, reload: bool) -> Vec<ModelSlot> {
+        if reload {
+            self.reload_slots();
+        }
+        self.slots
+            .read()
+            .map(|v| v.clone())
+            .unwrap_or_else(|_| Vec::new())
+    }
+
+    /// Retrieve a single slot by index.
+    pub fn get_slot_info(&self, slot: usize) -> Option<ModelSlot> {
+        self.slots
+            .read()
+            .ok()
+            .and_then(|v| v.get(slot).cloned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn save_and_load() {
+        let dir = tempdir().unwrap();
+        let manager = ModelSlotManager::new(dir.path().to_str().unwrap().to_string());
+        let info = ModelSlot::RVC(RVCModelSlot {
+            model_file: "a.pth".into(),
+            sampling_rate: 48000,
+        });
+        manager.save_model_slot(0, &info).unwrap();
+        let loaded = manager.load_model_slot(0).unwrap();
+        match loaded {
+            ModelSlot::RVC(r) => {
+                assert_eq!(r.model_file, "a.pth");
+                assert_eq!(r.sampling_rate, 48000);
+            }
+            _ => panic!("invalid slot"),
+        }
+    }
+
+    #[test]
+    fn update_model_info_modifies_file() {
+        let dir = tempdir().unwrap();
+        let manager = ModelSlotManager::new(dir.path().to_str().unwrap().to_string());
+        let info = ModelSlot::RVC(RVCModelSlot {
+            model_file: "a.pth".into(),
+            sampling_rate: 48000,
+        });
+        manager.save_model_slot(0, &info).unwrap();
+        let data = serde_json::json!({"slot":0,"key":"samplingRate","val":44100}).to_string();
+        manager.update_model_info(&data).unwrap();
+        let loaded = manager.load_model_slot(0).unwrap();
+        match loaded {
+            ModelSlot::RVC(r) => {
+                assert_eq!(r.sampling_rate, 44100);
+            }
+            _ => panic!("invalid"),
+        }
+    }
+
+    #[test]
+    fn store_model_assets_moves_file() {
+        let dir = tempdir().unwrap();
+        let upload_dir = Path::new(UPLOAD_DIR);
+        fs::create_dir_all(upload_dir).unwrap();
+        let file_path = upload_dir.join("test.txt");
+        fs::write(&file_path, b"data").unwrap();
+        let manager = ModelSlotManager::new(dir.path().to_str().unwrap().to_string());
+        manager
+            .save_model_slot(0, &ModelSlot::RVC(RVCModelSlot::default()))
+            .unwrap();
+        let params = serde_json::json!({"slot":0,"file":"test.txt","name":"modelFile"}).to_string();
+        manager.store_model_assets(&params).unwrap();
+        assert!(dir.path().join("0").join("test.txt").exists());
+        let loaded = manager.load_model_slot(0).unwrap();
+        match loaded {
+            ModelSlot::RVC(r) => assert_eq!(r.model_file, "test.txt"),
+            _ => panic!("invalid"),
+        }
+
+        let all = manager.get_all_slot_info(false);
+        assert_eq!(all.len(), MAX_SLOT_NUM);
+
+        assert!(matches!(manager.get_slot_info(0), Some(ModelSlot::RVC(_))));
     }
 }

--- a/server-rs/src/model_slot.rs
+++ b/server-rs/src/model_slot.rs
@@ -32,7 +32,7 @@ impl Default for RVCModelSlot {
 
 pub struct ModelSlotManager {
     model_dir: String,
-    slots: RwLock<Vec<ModelSlot>>, 
+    slots: RwLock<Vec<ModelSlot>>,
 }
 
 impl ModelSlotManager {
@@ -168,19 +168,19 @@ impl ModelSlotManager {
 
     /// Retrieve a single slot by index.
     pub fn get_slot_info(&self, slot: usize) -> Option<ModelSlot> {
-        self.slots
-            .read()
-            .ok()
-            .and_then(|v| v.get(slot).cloned())
+        self.slots.read().ok().and_then(|v| v.get(slot).cloned())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::cleanup_test_dirs;
+    use serial_test::serial;
     use tempfile::tempdir;
 
     #[test]
+    #[serial]
     fn save_and_load() {
         let dir = tempdir().unwrap();
         let manager = ModelSlotManager::new(dir.path().to_str().unwrap().to_string());
@@ -197,9 +197,11 @@ mod tests {
             }
             _ => panic!("invalid slot"),
         }
+        cleanup_test_dirs();
     }
 
     #[test]
+    #[serial]
     fn update_model_info_modifies_file() {
         let dir = tempdir().unwrap();
         let manager = ModelSlotManager::new(dir.path().to_str().unwrap().to_string());
@@ -217,9 +219,11 @@ mod tests {
             }
             _ => panic!("invalid"),
         }
+        cleanup_test_dirs();
     }
 
     #[test]
+    #[serial]
     fn store_model_assets_moves_file() {
         let dir = tempdir().unwrap();
         let upload_dir = Path::new(UPLOAD_DIR);
@@ -243,5 +247,6 @@ mod tests {
         assert_eq!(all.len(), MAX_SLOT_NUM);
 
         assert!(matches!(manager.get_slot_info(0), Some(ModelSlot::RVC(_))));
+        cleanup_test_dirs();
     }
 }

--- a/server-rs/src/plugin.rs
+++ b/server-rs/src/plugin.rs
@@ -1,4 +1,4 @@
-pub use crate::rvc::VCModel;
+pub use crate::rvc::{VCModel, VoiceChangerModel};
 use crate::model_slot::ModelSlot;
 use crate::voice_changer_params::VoiceChangerParams;
 

--- a/server-rs/src/rvc.rs
+++ b/server-rs/src/rvc.rs
@@ -3,19 +3,156 @@ pub trait VCModel: Send + Sync {
     fn inference(&self, input: &[i16]) -> Vec<i16>;
 }
 
+use crate::constants::TMP_DIR;
 use crate::model_slot::{ModelSlot, RVCModelSlot};
 use crate::plugin::VCModelPlugin;
 use crate::voice_changer_params::VoiceChangerParams;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::path::Path;
+
+/// Runtime settings mirrored from the Python `RVCSettings` dataclass.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RvcSettings {
+    pub gpu: i32,
+    #[serde(rename = "dstId")]
+    pub dst_id: i32,
+    #[serde(rename = "f0Detector")]
+    pub f0_detector: String,
+    pub tran: i32,
+    #[serde(rename = "silentThreshold")]
+    pub silent_threshold: f32,
+    #[serde(rename = "extraConvertSize")]
+    pub extra_convert_size: i32,
+    #[serde(rename = "indexRatio")]
+    pub index_ratio: f32,
+    pub protect: f32,
+    #[serde(rename = "rvcQuality")]
+    pub rvc_quality: i32,
+    #[serde(rename = "silenceFront")]
+    pub silence_front: i32,
+    #[serde(rename = "modelSamplingRate")]
+    pub model_sampling_rate: i32,
+}
+
+impl Default for RvcSettings {
+    fn default() -> Self {
+        Self {
+            gpu: -9999,
+            dst_id: 0,
+            f0_detector: "rmvpe_onnx".into(),
+            tran: 12,
+            silent_threshold: 0.00001,
+            extra_convert_size: 4096,
+            index_ratio: 0.0,
+            protect: 0.5,
+            rvc_quality: 0,
+            silence_front: 1,
+            model_sampling_rate: 48000,
+        }
+    }
+}
 
 pub struct Rvc {
     sample_rate: i32,
     #[allow(dead_code)]
     path: String,
+    settings: RvcSettings,
 }
 
 impl Rvc {
     pub fn new(sample_rate: i32, path: String) -> Self {
-        Self { sample_rate, path }
+        Self {
+            sample_rate,
+            path,
+            settings: RvcSettings::default(),
+        }
+    }
+
+    /// Update runtime settings from a JSON key/value pair.
+    pub fn update_settings(&mut self, key: &str, val: Value) -> bool {
+        match key {
+            "gpu" => {
+                if let Some(v) = val.as_i64() {
+                    self.settings.gpu = v as i32;
+                }
+            }
+            "dstId" => {
+                if let Some(v) = val.as_i64() {
+                    self.settings.dst_id = v as i32;
+                }
+            }
+            "f0Detector" => {
+                if let Some(v) = val.as_str() {
+                    self.settings.f0_detector = v.to_string();
+                }
+            }
+            "tran" => {
+                if let Some(v) = val.as_i64() {
+                    self.settings.tran = v as i32;
+                }
+            }
+            "silentThreshold" => {
+                if let Some(v) = val.as_f64() {
+                    self.settings.silent_threshold = v as f32;
+                }
+            }
+            "extraConvertSize" => {
+                if let Some(v) = val.as_i64() {
+                    self.settings.extra_convert_size = v as i32;
+                }
+            }
+            "indexRatio" => {
+                if let Some(v) = val.as_f64() {
+                    self.settings.index_ratio = v as f32;
+                }
+            }
+            "protect" => {
+                if let Some(v) = val.as_f64() {
+                    self.settings.protect = v as f32;
+                }
+            }
+            "rvcQuality" => {
+                if let Some(v) = val.as_i64() {
+                    self.settings.rvc_quality = v as i32;
+                }
+            }
+            "silenceFront" => {
+                if let Some(v) = val.as_i64() {
+                    self.settings.silence_front = v as i32;
+                }
+            }
+            "modelSamplingRate" => {
+                if let Some(v) = val.as_i64() {
+                    self.settings.model_sampling_rate = v as i32;
+                }
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    /// Return settings information in JSON format.
+    pub fn get_info(&self) -> Value {
+        json!(self.settings)
+    }
+
+    /// Export the model to ONNX by writing a dummy file into [`TMP_DIR`].
+    pub fn export_to_onnx(&self) -> std::io::Result<String> {
+        let dir = Path::new(TMP_DIR);
+        std::fs::create_dir_all(dir)?;
+        let path = dir.join("rvc_model.onnx");
+        std::fs::write(&path, b"dummy onnx")?;
+        Ok(path.to_string_lossy().to_string())
+    }
+
+    /// Return key/value pairs representing current model defaults.
+    pub fn get_model_current(&self) -> Vec<Value> {
+        vec![
+            json!({"key": "defaultTune", "val": self.settings.tran}),
+            json!({"key": "defaultIndexRatio", "val": self.settings.index_ratio}),
+            json!({"key": "defaultProtect", "val": self.settings.protect}),
+        ]
     }
 }
 
@@ -41,5 +178,34 @@ impl VCModelPlugin for RvcPlugin {
             ModelSlot::RVC(info) => Box::new(Rvc::new(info.sampling_rate, info.model_file.clone())),
             _ => Box::new(Rvc::new(48000, String::new())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_and_get_info() {
+        let mut r = Rvc::new(48000, "m.pth".into());
+        assert_eq!(r.processing_sample_rate(), 48000);
+        r.update_settings("tran", Value::from(7));
+        let info = r.get_info();
+        assert_eq!(info["tran"], 7);
+    }
+
+    #[test]
+    fn export_to_onnx_writes_file() {
+        let r = Rvc::new(48000, String::new());
+        let path = r.export_to_onnx().unwrap();
+        assert!(std::path::Path::new(&path).exists());
+    }
+
+    #[test]
+    fn get_model_current_contains_keys() {
+        let r = Rvc::new(48000, String::new());
+        let cur = r.get_model_current();
+        assert_eq!(cur.len(), 3);
+        assert_eq!(cur[0]["key"], "defaultTune");
     }
 }

--- a/server-rs/src/rvc.rs
+++ b/server-rs/src/rvc.rs
@@ -260,28 +260,36 @@ impl VCModelPlugin for RvcPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::cleanup_test_dirs;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn update_and_get_info() {
         let mut r = Rvc::new(48000, "m.pth".into());
         assert_eq!(r.processing_sample_rate(), 48000);
         r.update_settings("tran", Value::from(7));
         let info = r.get_info();
         assert_eq!(info["tran"], 7);
+        cleanup_test_dirs();
     }
 
     #[test]
+    #[serial]
     fn export_to_onnx_writes_file() {
         let r = Rvc::new(48000, String::new());
         let path = r.export_to_onnx().unwrap();
         assert!(std::path::Path::new(&path).exists());
+        cleanup_test_dirs();
     }
 
     #[test]
+    #[serial]
     fn get_model_current_contains_keys() {
         let r = Rvc::new(48000, String::new());
         let cur = r.get_model_current();
         assert_eq!(cur.len(), 3);
         assert_eq!(cur[0]["key"], "defaultTune");
+        cleanup_test_dirs();
     }
 }

--- a/server-rs/src/rvc.rs
+++ b/server-rs/src/rvc.rs
@@ -1,10 +1,30 @@
-pub trait VCModel: Send + Sync {
+/// Trait mirroring the Python `VoiceChangerModel` protocol.
+pub trait VoiceChangerModel: Send + Sync {
+    /// Return the sample rate expected by the model.
     fn processing_sample_rate(&self) -> i32;
+    /// Run inference on an audio buffer.
     fn inference(&self, input: &[i16]) -> Vec<i16>;
+    /// Update internal settings using a key/value pair.
+    fn update_settings(&mut self, key: &str, val: Value) -> bool;
+    /// Return a JSON object describing current settings.
+    fn get_info(&self) -> Value;
+    /// Prepare model input. The default implementation simply returns the
+    /// received audio and a calculated volume.
+    fn generate_input(
+        &mut self,
+        new_data: &[i16],
+        input_size: usize,
+        crossfade_size: usize,
+        sola_search_frame: usize,
+    ) -> (Vec<i16>, Vec<i16>, Vec<i16>, usize, f32, usize);
 }
 
+/// Marker trait used throughout the Rust server implementation.  It extends
+/// [`VoiceChangerModel`] so concrete models only need to implement that one.
+pub trait VCModel: VoiceChangerModel {}
+
 use crate::constants::TMP_DIR;
-use crate::model_slot::{ModelSlot, RVCModelSlot};
+use crate::model_slot::ModelSlot;
 use crate::plugin::VCModelPlugin;
 use crate::voice_changer_params::VoiceChangerParams;
 use serde::{Deserialize, Serialize};
@@ -58,6 +78,7 @@ pub struct Rvc {
     #[allow(dead_code)]
     path: String,
     settings: RvcSettings,
+    audio_buffer: Vec<i16>,
 }
 
 impl Rvc {
@@ -66,6 +87,7 @@ impl Rvc {
             sample_rate,
             path,
             settings: RvcSettings::default(),
+            audio_buffer: Vec::new(),
         }
     }
 
@@ -156,7 +178,7 @@ impl Rvc {
     }
 }
 
-impl VCModel for Rvc {
+impl VoiceChangerModel for Rvc {
     fn processing_sample_rate(&self) -> i32 {
         self.sample_rate
     }
@@ -164,7 +186,61 @@ impl VCModel for Rvc {
     fn inference(&self, input: &[i16]) -> Vec<i16> {
         input.to_vec()
     }
+
+    fn update_settings(&mut self, key: &str, val: Value) -> bool {
+        Rvc::update_settings(self, key, val)
+    }
+
+    fn get_info(&self) -> Value {
+        Rvc::get_info(self)
+    }
+
+    fn generate_input(
+        &mut self,
+        new_data: &[i16],
+        input_size: usize,
+        crossfade_size: usize,
+        sola_search_frame: usize,
+    ) -> (Vec<i16>, Vec<i16>, Vec<i16>, usize, f32, usize) {
+        // Simplified implementation mirroring the Python interface.
+        let convert_size = input_size
+            + crossfade_size
+            + sola_search_frame
+            + self.settings.extra_convert_size as usize;
+        self.audio_buffer.extend_from_slice(new_data);
+        if self.audio_buffer.len() > convert_size {
+            let excess = self.audio_buffer.len() - convert_size;
+            self.audio_buffer.drain(0..excess);
+        }
+        let vol_segment = self
+            .audio_buffer
+            .iter()
+            .rev()
+            .take(input_size + crossfade_size)
+            .cloned()
+            .collect::<Vec<_>>();
+        let vol = if vol_segment.is_empty() {
+            0.0
+        } else {
+            let mean = vol_segment
+                .iter()
+                .map(|v| *v as f32 * *v as f32)
+                .sum::<f32>()
+                / vol_segment.len() as f32;
+            mean.sqrt()
+        };
+        (
+            self.audio_buffer.clone(),
+            Vec::new(),
+            Vec::new(),
+            convert_size,
+            vol,
+            input_size + crossfade_size,
+        )
+    }
 }
+
+impl VCModel for Rvc {}
 
 pub struct RvcPlugin;
 

--- a/server-rs/src/test_util.rs
+++ b/server-rs/src/test_util.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+pub fn cleanup_test_dirs() {
+    let _ = std::fs::remove_dir_all("m");
+    let _ = std::fs::remove_dir_all("upload_dir");
+    let _ = std::fs::remove_dir_all("tmp_dir");
+}

--- a/server-rs/src/voice_changer.rs
+++ b/server-rs/src/voice_changer.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::sync::RwLock;
 
 use crate::constants::TMP_DIR;
-use crate::rvc::{VCModel, Rvc};
+use crate::rvc::VCModel;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VoiceChangerSettings {
@@ -307,17 +307,46 @@ fn generate_strength(size: usize, offset_rate: f32, end_rate: f32) -> (Vec<f32>,
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rvc::VoiceChangerModel;
 
     struct DummyModel;
 
-    impl VCModel for DummyModel {
+    impl VoiceChangerModel for DummyModel {
         fn processing_sample_rate(&self) -> i32 {
             16000
         }
+
         fn inference(&self, input: &[i16]) -> Vec<i16> {
             input.to_vec()
         }
+
+        fn update_settings(&mut self, _key: &str, _val: Value) -> bool {
+            true
+        }
+
+        fn get_info(&self) -> Value {
+            serde_json::json!({})
+        }
+
+        fn generate_input(
+            &mut self,
+            new_data: &[i16],
+            _input_size: usize,
+            _crossfade_size: usize,
+            _sola_search_frame: usize,
+        ) -> (Vec<i16>, Vec<i16>, Vec<i16>, usize, f32, usize) {
+            (
+                new_data.to_vec(),
+                Vec::new(),
+                Vec::new(),
+                new_data.len(),
+                0.0,
+                new_data.len(),
+            )
+        }
     }
+
+    impl VCModel for DummyModel {}
 
     #[test]
     fn sample_rate_methods() {

--- a/server-rs/src/voice_changer.rs
+++ b/server-rs/src/voice_changer.rs
@@ -238,7 +238,7 @@ impl VoiceChanger {
         true
     }
 
-    /// Update model defaults. mark by updating performance[0].
+    /// Update model defaults by incrementing `performance[0]`.
     pub fn update_model_default(&self) {
         if let Ok(mut s) = self.settings.write() {
             if let Some(p) = s.performance.get_mut(0) {
@@ -247,7 +247,7 @@ impl VoiceChanger {
         }
     }
 
-    /// Update model metadata, mark by updating performance[1].
+    /// Update model metadata by incrementing `performance[1]`.
     pub fn update_model_info(&self, _new_data: &str) {
         if let Ok(mut s) = self.settings.write() {
             if let Some(p) = s.performance.get_mut(1) {
@@ -256,7 +256,7 @@ impl VoiceChanger {
         }
     }
 
-    /// Upload additional model assets, mark by updating performance[2].
+    /// Upload additional model assets by incrementing `performance[2]`.
     pub fn upload_model_assets(&self, _params: &str) {
         if let Ok(mut s) = self.settings.write() {
             if let Some(p) = s.performance.get_mut(2) {

--- a/server-rs/src/voice_changer.rs
+++ b/server-rs/src/voice_changer.rs
@@ -308,6 +308,8 @@ fn generate_strength(size: usize, offset_rate: f32, end_rate: f32) -> (Vec<f32>,
 mod tests {
     use super::*;
     use crate::rvc::VoiceChangerModel;
+    use crate::test_util::cleanup_test_dirs;
+    use serial_test::serial;
 
     struct DummyModel;
 
@@ -349,6 +351,7 @@ mod tests {
     impl VCModel for DummyModel {}
 
     #[test]
+    #[serial]
     fn sample_rate_methods() {
         let vc = VoiceChanger::new();
         vc.set_input_sample_rate(24000);
@@ -356,9 +359,11 @@ mod tests {
         let info = vc.get_info();
         assert_eq!(info.input_sample_rate, 24000);
         assert_eq!(info.output_sample_rate, 24000);
+        cleanup_test_dirs();
     }
 
     #[test]
+    #[serial]
     fn model_inference_and_processing_rate() {
         let vc = VoiceChanger::new();
         vc.set_model(DummyModel);
@@ -366,5 +371,6 @@ mod tests {
         assert_eq!(rate, 16000);
         let out = vc.change_voice(&[1, 2, 3]);
         assert_eq!(out, vec![1, 2, 3]);
+        cleanup_test_dirs();
     }
 }

--- a/server-rs/src/voice_changer_manager.rs
+++ b/server-rs/src/voice_changer_manager.rs
@@ -305,11 +305,7 @@ mod tests {
     #[test]
     fn load_model_moves_files() {
         let dir_path = Path::new("m");
-        std::fs::create_dir_all(dir_path).unwrap();
         let upload_dir = Path::new("upload_dir");
-        std::fs::create_dir_all(upload_dir).unwrap();
-        let src = upload_dir.join("model.pth");
-        std::fs::write(&src, b"dummy").unwrap();
 
         let params = VoiceChangerParams {
             model_dir: dir_path.to_str().unwrap().into(),
@@ -330,6 +326,11 @@ mod tests {
         let manager = VoiceChangerManager::get_instance(params);
         #[cfg(test)]
         manager.reset();
+
+        std::fs::create_dir_all(dir_path).unwrap();
+        std::fs::create_dir_all(upload_dir).unwrap();
+        let src = upload_dir.join("model.pth");
+        std::fs::write(&src, b"dummy").unwrap();
 
         let req = LoadModelRequest {
             voice_changer_type: "RVC".into(),

--- a/server-rs/src/voice_changer_manager.rs
+++ b/server-rs/src/voice_changer_manager.rs
@@ -6,10 +6,10 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 use crate::constants::STORED_SETTING_FILE;
-use crate::voice_changer::VoiceChanger;
+use crate::model_slot::{ModelSlot, ModelSlotManager, RVCModelSlot};
 use crate::plugin::VCModelPlugin;
 use crate::rvc::RvcPlugin;
-use crate::model_slot::{ModelSlot, RVCModelSlot};
+use crate::voice_changer::VoiceChanger;
 
 use crate::voice_changer_params::VoiceChangerParams;
 
@@ -65,6 +65,7 @@ pub struct VoiceChangerManager {
     stored_setting: RwLock<HashMap<String, Value>>,
     plugins: RwLock<HashMap<String, Arc<dyn VCModelPlugin>>>,
     current_slot: RwLock<Option<ModelSlot>>,
+    model_slot_manager: ModelSlotManager,
 }
 
 static INSTANCE: OnceCell<VoiceChangerManager> = OnceCell::new();
@@ -72,6 +73,7 @@ static INSTANCE: OnceCell<VoiceChangerManager> = OnceCell::new();
 impl VoiceChangerManager {
     pub fn get_instance(params: VoiceChangerParams) -> &'static VoiceChangerManager {
         INSTANCE.get_or_init(|| {
+            let msm = ModelSlotManager::new(params.model_dir.clone());
             let mut m = Self {
                 params,
                 settings: RwLock::new(VoiceChangerManagerSettings::default()),
@@ -81,6 +83,7 @@ impl VoiceChangerManager {
                 stored_setting: RwLock::new(HashMap::new()),
                 plugins: RwLock::new(HashMap::new()),
                 current_slot: RwLock::new(None),
+                model_slot_manager: msm,
             };
             m.register_plugin(RvcPlugin);
             m.load_stored_settings();
@@ -119,6 +122,9 @@ impl VoiceChangerManager {
                 model_file: path.clone(),
                 sampling_rate: 48000,
             });
+            let _ = self
+                .model_slot_manager
+                .save_model_slot(params.slot as usize, &slot);
             if let Ok(mut cur) = self.current_slot.write() {
                 *cur = Some(slot.clone());
             }
@@ -137,7 +143,12 @@ impl VoiceChangerManager {
     }
 
     pub fn change_voice(&self, input: &[i16]) -> Vec<i16> {
-        if self.settings.read().map(|s| s.pass_through).unwrap_or(false) {
+        if self
+            .settings
+            .read()
+            .map(|s| s.pass_through)
+            .unwrap_or(false)
+        {
             return input.to_vec();
         }
         self.voice_changer.change_voice(input)
@@ -198,16 +209,26 @@ impl VoiceChangerManager {
 
     pub fn update_model_default(&self) -> serde_json::Value {
         self.voice_changer.update_model_default();
+        if let Ok(s) = self.settings.read() {
+            if s.model_slot_index >= 0 {
+                let data =
+                    serde_json::json!({"slot": s.model_slot_index, "key": "updated", "val": true})
+                        .to_string();
+                let _ = self.model_slot_manager.update_model_info(&data);
+            }
+        }
         self.get_info()
     }
 
     pub fn update_model_info(&self, new_data: &str) -> serde_json::Value {
         self.voice_changer.update_model_info(new_data);
+        let _ = self.model_slot_manager.update_model_info(new_data);
         self.get_info()
     }
 
     pub fn upload_model_assets(&self, params: &str) -> serde_json::Value {
         self.voice_changer.upload_model_assets(params);
+        let _ = self.model_slot_manager.store_model_assets(params);
         self.get_info()
     }
 }

--- a/server-rs/src/volume_extractor.rs
+++ b/server-rs/src/volume_extractor.rs
@@ -1,0 +1,170 @@
+//! Volume extraction utilities translated from the Python implementation.
+//!
+//! The original Python code relies heavily on PyTorch for tensor
+//! operations. This Rust version implements the same algorithms using
+//! safe Rust and `Vec` math so that no heavy dependencies are required.
+
+use std::f32;
+
+/// Information about a [`VolumeExtractor`] instance returned by
+/// [`VolumeExtractor::get_volume_extractor_info`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VolumeExtractorInfo {
+    /// Hop size used for analysis.
+    pub hop_size: usize,
+}
+
+/// Rust translation of the Python `VolumeExtractor` class.
+///
+/// The Python implementation relied on PyTorch tensors.  This struct provides
+/// equivalent functionality using safe Rust code.
+#[derive(Debug, Clone)]
+pub struct VolumeExtractor {
+    hop_size: usize,
+}
+
+impl VolumeExtractor {
+    /// Create a new extractor configured with the given `hop_size`.
+    pub fn new(hop_size: usize) -> Self {
+        Self { hop_size }
+    }
+
+    /// Return the extractor configuration.
+    pub fn get_volume_extractor_info(&self) -> VolumeExtractorInfo {
+        VolumeExtractorInfo {
+            hop_size: self.hop_size,
+        }
+    }
+
+    /// Extract per-frame RMS volumes from an audio signal.
+    pub fn extract(&self, audio: &[f32]) -> Vec<f32> {
+        extract_impl(audio, self.hop_size)
+    }
+
+    /// Sliding RMS variant matching the Python `extract_t` method.
+    pub fn extract_t(&self, audio: &[f32]) -> Vec<f32> {
+        self.extract(audio)
+    }
+
+    /// Generate a voice activity mask from volume values.
+    pub fn get_mask_from_volume(
+        &self,
+        volume: &[f32],
+        block_size: usize,
+        threshold: f32,
+    ) -> Vec<f32> {
+        get_mask_from_volume_impl(volume, block_size, threshold)
+    }
+
+    /// Equivalent to `get_mask_from_volume` but kept for parity with the
+    /// Python code's `get_mask_from_volume_t`.
+    pub fn get_mask_from_volume_t(
+        &self,
+        volume: &[f32],
+        block_size: usize,
+        threshold: f32,
+    ) -> Vec<f32> {
+        self.get_mask_from_volume(volume, block_size, threshold)
+    }
+}
+
+/// Extract per-frame RMS volumes from an audio signal.
+///
+/// `audio` should be a mono signal. `hop_size` defines the frame
+/// spacing in samples.
+fn extract_impl(audio: &[f32], hop_size: usize) -> Vec<f32> {
+    if hop_size == 0 {
+        return Vec::new();
+    }
+    let n_frames = audio.len() / hop_size + 1;
+    let mut out = Vec::with_capacity(n_frames);
+    for n in 0..n_frames {
+        let start = n * hop_size;
+        let end = ((n + 1) * hop_size).min(audio.len());
+        if start >= audio.len() {
+            out.push(out.last().cloned().unwrap_or(0.0));
+            continue;
+        }
+        let slice = &audio[start..end];
+        let mean = slice.iter().map(|v| v * v).sum::<f32>() / slice.len() as f32;
+        out.push(mean.sqrt());
+    }
+    out
+}
+
+/// Sliding RMS using the same algorithm as [`VolumeExtractor::extract`] but expecting an
+/// owned vector so the function can operate in place.
+fn extract_t_impl(audio: &[f32], hop_size: usize) -> Vec<f32> {
+    extract_impl(audio, hop_size)
+}
+
+/// Generate a voice activity mask from volume values.
+///
+/// `block_size` specifies the upsample factor used by the caller.
+/// `threshold` is in dB.
+fn get_mask_from_volume_impl(volume: &[f32], block_size: usize, threshold: f32) -> Vec<f32> {
+    let db_threshold = 10f32.powf(threshold / 20.0);
+    let mut mask: Vec<f32> = volume
+        .iter()
+        .map(|v| if *v > db_threshold { 1.0 } else { 0.0 })
+        .collect();
+    if mask.is_empty() {
+        return mask;
+    }
+    let first = mask[0];
+    let last = *mask.last().unwrap();
+    for _ in 0..4 {
+        mask.insert(0, first);
+        mask.push(last);
+    }
+    let mut smoothed = Vec::with_capacity(mask.len() - 8);
+    for n in 0..mask.len() - 8 {
+        let max = mask[n..n + 9].iter().fold(0.0f32, |m, &v| m.max(v));
+        smoothed.push(max);
+    }
+    upsample(&smoothed, block_size)
+}
+
+/// Upsample a 1‑D signal by linear interpolation.
+fn upsample(signal: &[f32], factor: usize) -> Vec<f32> {
+    if signal.is_empty() || factor == 0 {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(signal.len() * factor);
+    for i in 0..signal.len() - 1 {
+        let cur = signal[i];
+        let next = signal[i + 1];
+        for j in 0..factor {
+            let t = j as f32 / factor as f32;
+            out.push(cur * (1.0 - t) + next * t);
+        }
+    }
+    out.push(*signal.last().unwrap());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_basic() {
+        let audio = vec![0.0f32; 480];
+        let ext = VolumeExtractor::new(160);
+        let v = ext.extract(&audio);
+        assert_eq!(v.len(), 4); // 480/160 + 1
+        let info = ext.get_volume_extractor_info();
+        assert_eq!(info.hop_size, 160);
+    }
+
+    #[test]
+    fn test_mask_generation() {
+        let volume = vec![0.0, 0.5, 0.0, 0.5];
+        let ext = VolumeExtractor::new(1);
+        let mask = ext.get_mask_from_volume(&volume, 2, -6.0);
+        // Should upsample to (len + pad -8)*factor = (??). For this simple test,
+        // just verify output length.
+        assert!(!mask.is_empty());
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement runtime settings for `Rvc`
- add methods for updating settings, exporting ONNX, and reporting model defaults
- test the new `Rvc` functionality

## Testing
- `cargo test --quiet`
- `cargo doc --no-deps --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684ff257bc7883259e56f1f12e5cfd88