### PR TITLE
Implement socketioxide-based server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS
+
+## Goal
+
+The project aims to port the Python voice changer server under `server/` to a Rust
+implementation in `server-rs/`. When adding features in Rust, mirror the Python
+code structure and behavior as closely as possible.
+
+## Conventions
+
+- Run `cargo fmt` and `cargo test --quiet` before committing.
+- Document new modules and describe differences from Python where applicable.

--- a/server-rs/Cargo.toml
+++ b/server-rs/Cargo.toml
@@ -17,6 +17,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 futures-util = "0.3"
 tower-http = { version = "0.3", features = ["fs"] }
 reqwest = { version = "0.11", features = ["json"] }
+socketioxide = { version = "0.8", features = ["tracing", "state"] }
 
 [dev-dependencies]
 tower = "0.4"

--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -18,6 +18,7 @@ use voice_changer_manager::VoiceChangerManager;
 mod mmvc_rest;
 mod mmvc_socketio_app;
 mod mmvc_socketio_server;
+mod socketio_stub;
 mod volume_extractor;
 use mmvc_rest::MMVCRest;
 use mmvc_socketio_app::MMVCSocketIOApp;

--- a/server-rs/src/mmvc_rest.rs
+++ b/server-rs/src/mmvc_rest.rs
@@ -5,22 +5,16 @@
 //! clients.  Each handler is documented so `cargo doc` can generate API
 //! documentation for the HTTP routes.
 
-use axum::{
-    routing::{get, post},
-    Json, Router,
-};
+use axum::{routing::get, Json, Router};
 #[path = "mmvc_rest_fileuploader.rs"]
 mod mmvc_rest_fileuploader;
+#[path = "mmvc_rest_voice_changer.rs"]
+mod mmvc_rest_voice_changer;
 use crate::voice_changer_manager::VoiceChangerManager;
 use base64::{engine::general_purpose, Engine as _};
 use mmvc_rest_fileuploader::MMVCRestFileuploader;
-use once_cell::sync::OnceCell;
-use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use tokio::sync::Mutex;
-
-static MANAGER: OnceCell<&'static VoiceChangerManager> = OnceCell::new();
-static LOCK: OnceCell<Arc<Mutex<()>>> = OnceCell::new();
+use mmvc_rest_voice_changer::MMVCRestVoiceChanger;
+use serde::Serialize;
 
 /// Response for [`hello`] endpoint.
 #[derive(Serialize)]
@@ -36,52 +30,6 @@ async fn hello() -> Json<Hello> {
     Json(Hello { result: "Index" })
 }
 
-/// Request payload for [`test()`] endpoint.
-#[derive(Deserialize)]
-struct VoiceModel {
-    /// Arbitrary timestamp used by the caller.
-    timestamp: u64,
-    /// Little endian 16‑bit PCM samples encoded as base64.
-    buffer: String,
-}
-
-/// Response payload for [`test()`].
-#[derive(Serialize)]
-struct TestResponse {
-    /// Echoed timestamp from the request.
-    timestamp: u64,
-    /// Converted voice samples encoded as base64.
-    changed_voice_base64: String,
-}
-
-/// `POST /test`
-///
-/// Accepts base64 encoded audio samples and returns the modified voice.
-async fn test(Json(payload): Json<VoiceModel>) -> Json<TestResponse> {
-    let manager = MANAGER.get().expect("manager not set");
-    let lock = LOCK.get().expect("lock not set");
-    let bytes = match general_purpose::STANDARD.decode(&payload.buffer) {
-        Ok(b) => b,
-        Err(_) => Vec::new(),
-    };
-    let mut samples = Vec::with_capacity(bytes.len() / 2);
-    for chunk in bytes.chunks_exact(2) {
-        samples.push(i16::from_le_bytes([chunk[0], chunk[1]]));
-    }
-    let _guard = lock.lock().await;
-    let changed = manager.change_voice(&samples);
-    drop(_guard);
-    let mut out_bytes = Vec::with_capacity(changed.len() * 2);
-    for s in changed {
-        out_bytes.extend_from_slice(&s.to_le_bytes());
-    }
-    let encoded = general_purpose::STANDARD.encode(out_bytes);
-    Json(TestResponse {
-        timestamp: payload.timestamp,
-        changed_voice_base64: encoded,
-    })
-}
-
 /// REST API application.
 ///
 /// Use [`MMVCRest::new`] to create a router that exposes the HTTP endpoints
@@ -93,12 +41,11 @@ pub struct MMVCRest {
 impl MMVCRest {
     /// Construct a new [`MMVCRest`] using the provided manager instance.
     pub fn new(manager: &'static VoiceChangerManager) -> Self {
-        MANAGER.set(manager).ok();
-        LOCK.set(Arc::new(Mutex::new(()))).ok();
         let file_router = MMVCRestFileuploader::new(manager).router();
+        let vc_router = MMVCRestVoiceChanger::new(manager).router();
         let router = Router::new()
             .route("/api/hello", get(hello))
-            .route("/test", post(test))
+            .merge(vc_router)
             .merge(file_router);
         Self { router }
     }

--- a/server-rs/src/mmvc_rest_voice_changer.rs
+++ b/server-rs/src/mmvc_rest_voice_changer.rs
@@ -1,0 +1,131 @@
+use axum::{routing::post, Json, Router};
+use base64::{engine::general_purpose, Engine as _};
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::voice_changer_manager::VoiceChangerManager;
+
+static MANAGER: OnceCell<&'static VoiceChangerManager> = OnceCell::new();
+static LOCK: OnceCell<Arc<Mutex<()>>> = OnceCell::new();
+
+#[derive(Deserialize)]
+struct VoiceModel {
+    timestamp: u64,
+    buffer: String,
+}
+
+#[derive(Serialize)]
+struct TestResponse {
+    timestamp: u64,
+    changed_voice_base64: String,
+}
+
+async fn test(Json(payload): Json<VoiceModel>) -> Json<TestResponse> {
+    let manager = MANAGER.get().expect("manager not set");
+    let lock = LOCK.get().expect("lock not set");
+    let bytes = general_purpose::STANDARD
+        .decode(&payload.buffer)
+        .unwrap_or_default();
+    let mut samples = Vec::with_capacity(bytes.len() / 2);
+    for chunk in bytes.chunks_exact(2) {
+        samples.push(i16::from_le_bytes([chunk[0], chunk[1]]));
+    }
+    let _guard = lock.lock().await;
+    let changed = manager.change_voice(&samples);
+    drop(_guard);
+    let mut out_bytes = Vec::with_capacity(changed.len() * 2);
+    for s in changed {
+        out_bytes.extend_from_slice(&s.to_le_bytes());
+    }
+    let encoded = general_purpose::STANDARD.encode(out_bytes);
+    Json(TestResponse {
+        timestamp: payload.timestamp,
+        changed_voice_base64: encoded,
+    })
+}
+
+pub struct MMVCRestVoiceChanger {
+    router: Router,
+}
+
+impl MMVCRestVoiceChanger {
+    pub fn new(manager: &'static VoiceChangerManager) -> Self {
+        MANAGER.set(manager).ok();
+        LOCK.set(Arc::new(Mutex::new(()))).ok();
+        let router = Router::new().route("/test", post(test));
+        Self { router }
+    }
+
+    pub fn router(self) -> Router {
+        self.router
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        Router,
+    };
+    use serde_json::{json, Value};
+    use serial_test::serial;
+    use tower::ServiceExt;
+
+    use crate::{test_util::cleanup_test_dirs, voice_changer_params::VoiceChangerParams};
+
+    fn app() -> (Router, &'static VoiceChangerManager) {
+        let params = VoiceChangerParams {
+            model_dir: "m".into(),
+            content_vec_500: "".into(),
+            content_vec_500_onnx: "".into(),
+            content_vec_500_onnx_on: false,
+            hubert_base: "".into(),
+            hubert_base_jp: "".into(),
+            hubert_soft: "".into(),
+            nsf_hifigan: "".into(),
+            sample_mode: "".into(),
+            crepe_onnx_full: "".into(),
+            crepe_onnx_tiny: "".into(),
+            rmvpe: "".into(),
+            rmvpe_onnx: "".into(),
+            whisper_tiny: "".into(),
+        };
+        let manager = VoiceChangerManager::get_instance(params);
+        #[cfg(test)]
+        manager.reset();
+        (MMVCRestVoiceChanger::new(manager).router(), manager)
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_endpoint_echoes_payload() {
+        let (app, manager) = app();
+        let samples = vec![1i16, -2i16];
+        let bytes: Vec<u8> = samples.iter().flat_map(|x| x.to_le_bytes()).collect();
+        let encoded = general_purpose::STANDARD.encode(&bytes);
+        let payload = json!({"timestamp": 123u64, "buffer": encoded});
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .method("POST")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["timestamp"], 123);
+        assert_eq!(v["changed_voice_base64"], encoded);
+        manager.reset();
+        cleanup_test_dirs();
+    }
+}

--- a/server-rs/src/mmvc_socketio_app.rs
+++ b/server-rs/src/mmvc_socketio_app.rs
@@ -1,15 +1,10 @@
-use axum::{
-    http::StatusCode,
-    response::IntoResponse,
-    routing::get_service,
-    Router,
-};
+use axum::{http::StatusCode, response::IntoResponse, routing::get_service, Router};
 use tower_http::services::ServeDir;
 
 use crate::{
-    voice_changer_manager::VoiceChangerManager,
+    constants::{get_frontend_path, MODEL_DIR_STATIC, TMP_DIR, UPLOAD_DIR},
     mmvc_socketio_server::MMVCSocketIOServer,
-    constants::{get_frontend_path, TMP_DIR, UPLOAD_DIR, MODEL_DIR_STATIC},
+    voice_changer_manager::VoiceChangerManager,
 };
 
 pub struct MMVCSocketIOApp {
@@ -18,7 +13,7 @@ pub struct MMVCSocketIOApp {
 
 impl MMVCSocketIOApp {
     pub fn new(rest_router: Router, manager: &'static VoiceChangerManager) -> Self {
-        let socket_router = MMVCSocketIOServer::new(manager).router();
+        let socket_layer = MMVCSocketIOServer::new(manager).layer();
 
         // static file serving similar to the Python implementation
         let frontend = get_frontend_path();
@@ -28,7 +23,7 @@ impl MMVCSocketIOApp {
         };
 
         let router = rest_router
-            .merge(socket_router)
+            .layer(socket_layer)
             .nest_service("/front", serve_front(frontend.clone()))
             .nest_service("/trainer", serve_front(frontend.clone()))
             .nest_service("/recorder", serve_front(frontend.clone()))

--- a/server-rs/src/mmvc_socketio_server.rs
+++ b/server-rs/src/mmvc_socketio_server.rs
@@ -1,14 +1,11 @@
-use axum::{
-    extract::ws::{Message, WebSocket, WebSocketUpgrade},
-    response::IntoResponse,
-    routing::get,
-    Router,
-};
 use base64::{engine::general_purpose, Engine as _};
-use futures_util::{SinkExt, StreamExt};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
+use socketioxide::{
+    extract::{Data, SocketRef, State},
+    layer::SocketIoLayer,
+    SocketIo,
+};
 
 use crate::voice_changer_manager::VoiceChangerManager;
 
@@ -26,163 +23,49 @@ struct VoiceResponse {
     changed_voice_base64: String,
 }
 
-async fn ws_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
-    ws.on_upgrade(handle_socket)
-}
-
-async fn handle_socket(socket: WebSocket) {
-    let manager = MANAGER.get().expect("manager not set");
-    manager.clear_prev_audio();
-    let (mut sender, mut receiver) = socket.split();
-    let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
-    let tx_clone = tx.clone();
-
-    manager.set_emit_to(move |perf| {
-        let msg = Message::Text(serde_json::json!({ "perf": perf }).to_string());
-        let _ = tx_clone.send(msg);
-    });
-
-    let send_task = tokio::spawn(async move {
-        while let Some(msg) = rx.recv().await {
-            if sender.send(msg).await.is_err() {
-                break;
-            }
-        }
-    });
-
-    while let Some(Ok(msg)) = receiver.next().await {
-        match msg {
-            Message::Text(text) => {
-                if let Ok(payload) = serde_json::from_str::<VoiceModel>(&text) {
-                    let bytes = general_purpose::STANDARD
-                        .decode(&payload.buffer)
-                        .unwrap_or_default();
-                    let mut samples = Vec::with_capacity(bytes.len() / 2);
-                    for chunk in bytes.chunks_exact(2) {
-                        samples.push(i16::from_le_bytes([chunk[0], chunk[1]]));
-                    }
-                    let changed = manager.change_voice(&samples);
-                    let mut out_bytes = Vec::with_capacity(changed.len() * 2);
-                    for s in changed {
-                        out_bytes.extend_from_slice(&s.to_le_bytes());
-                    }
-                    let encoded = general_purpose::STANDARD.encode(out_bytes);
-                    let resp = VoiceResponse {
-                        timestamp: payload.timestamp,
-                        changed_voice_base64: encoded,
-                    };
-                    let msg = Message::Text(serde_json::to_string(&resp).unwrap());
-                    if tx.send(msg).is_err() {
-                        break;
-                    }
-                } else if tx.send(Message::Text(text)).is_err() {
-                    break;
-                }
-            }
-            Message::Binary(bin) => {
-                if tx.send(Message::Binary(bin)).is_err() {
-                    break;
-                }
-            }
-            Message::Close(_) => break,
-            _ => {}
-        }
-    }
-
-    send_task.abort();
-}
-
 pub struct MMVCSocketIOServer {
-    router: Router,
+    layer: SocketIoLayer,
 }
 
 impl MMVCSocketIOServer {
     pub fn new(manager: &'static VoiceChangerManager) -> Self {
         MANAGER.set(manager).ok();
-        let router = Router::new().route("/ws", get(ws_handler));
-        Self { router }
+        let (layer, io) = SocketIo::builder().with_state(manager).build_layer();
+
+        io.ns(
+            "/test",
+            |socket: SocketRef, State(manager): State<&'static VoiceChangerManager>| {
+                manager.clear_prev_audio();
+                socket.on(
+                    "request_message",
+                    move |socket: SocketRef, Data::<VoiceModel>(payload)| async move {
+                        let bytes = general_purpose::STANDARD
+                            .decode(&payload.buffer)
+                            .unwrap_or_default();
+                        let mut samples = Vec::with_capacity(bytes.len() / 2);
+                        for chunk in bytes.chunks_exact(2) {
+                            samples.push(i16::from_le_bytes([chunk[0], chunk[1]]));
+                        }
+                        let changed = manager.change_voice(&samples);
+                        let mut out_bytes = Vec::with_capacity(changed.len() * 2);
+                        for s in changed {
+                            out_bytes.extend_from_slice(&s.to_le_bytes());
+                        }
+                        let encoded = general_purpose::STANDARD.encode(out_bytes);
+                        let resp = VoiceResponse {
+                            timestamp: payload.timestamp,
+                            changed_voice_base64: encoded,
+                        };
+                        let _ = socket.emit("response", resp);
+                    },
+                );
+            },
+        );
+
+        Self { layer }
     }
 
-    pub fn router(self) -> Router {
-        self.router
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::body::Body;
-    use axum::Router;
-    use futures_util::StreamExt;
-    use serde_json::{json, Value};
-    use serial_test::serial;
-    use tokio_tungstenite::connect_async;
-    use tokio_tungstenite::tungstenite::Message as WsMessage;
-
-    use crate::voice_changer_params::VoiceChangerParams;
-
-    async fn start_server(app: Router) -> std::net::SocketAddr {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::Server::from_tcp(listener.into_std().unwrap())
-                .unwrap()
-                .serve(app.into_make_service())
-                .await
-                .unwrap();
-        });
-        // small delay to ensure server starts
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        addr
-    }
-
-    use crate::test_util::cleanup_test_dirs;
-    fn app() -> (Router, &'static VoiceChangerManager) {
-        let params = VoiceChangerParams {
-            model_dir: "m".into(),
-            content_vec_500: "".into(),
-            content_vec_500_onnx: "".into(),
-            content_vec_500_onnx_on: false,
-            hubert_base: "".into(),
-            hubert_base_jp: "".into(),
-            hubert_soft: "".into(),
-            nsf_hifigan: "".into(),
-            sample_mode: "".into(),
-            crepe_onnx_full: "".into(),
-            crepe_onnx_tiny: "".into(),
-            rmvpe: "".into(),
-            rmvpe_onnx: "".into(),
-            whisper_tiny: "".into(),
-        };
-        let manager = VoiceChangerManager::get_instance(params);
-        #[cfg(test)]
-        manager.reset();
-        (MMVCSocketIOServer::new(manager).router(), manager)
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn websocket_returns_changed_voice() {
-        let (app, manager) = app();
-        let addr = start_server(app).await;
-        let url = format!("ws://{}/ws", addr);
-        let (mut ws_stream, _) = connect_async(url).await.unwrap();
-
-        let samples = vec![1i16, -2i16];
-        let bytes: Vec<u8> = samples.iter().flat_map(|x| x.to_le_bytes()).collect();
-        let encoded = general_purpose::STANDARD.encode(&bytes);
-        let payload = json!({"timestamp":123u64,"buffer":encoded}).to_string();
-        ws_stream.send(WsMessage::Text(payload)).await.unwrap();
-
-        if let Some(Ok(WsMessage::Text(resp))) = ws_stream.next().await {
-            let v: Value = serde_json::from_str(&resp).unwrap();
-            assert_eq!(v["timestamp"], 123);
-            assert_eq!(v["changed_voice_base64"], encoded);
-        } else {
-            panic!("no response");
-        }
-
-        manager.reset();
-        cleanup_test_dirs();
+    pub fn layer(self) -> SocketIoLayer {
+        self.layer
     }
 }

--- a/server-rs/src/socketio_stub.rs
+++ b/server-rs/src/socketio_stub.rs
@@ -1,0 +1,23 @@
+/// Placeholder module for future Socket.IO support.
+///
+/// The current Rust implementation only exposes a plain WebSocket endpoint.
+/// In the Python server, Socket.IO is used to send binary audio frames and
+/// receive processed results. Implementing the full protocol requires
+/// compatibility with Engine.IO and the Socket.IO framing format, which is
+/// non-trivial.
+///
+/// This file provides a minimal stub that documents the intended interface.
+
+pub struct SocketIOServer;
+
+impl SocketIOServer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Start the Socket.IO server. Currently unimplemented.
+    pub async fn start(&self) {
+        // TODO: implement Socket.IO handling using an appropriate crate
+        // or a custom implementation compatible with the Python version.
+    }
+}


### PR DESCRIPTION
## Summary
- add `socketioxide` crate
- rewrite `MMVCSocketIOServer` to use Socket.IO library
- integrate Socket.IO layer in the main app router

## Testing
- `cargo fmt`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6850c4a7d35c8325af1c49881c5688d6